### PR TITLE
[FEAT] 매칭 신청 API, 매칭 수락 API, 매칭 거절 API, 내가 보낸 매칭 요청 삭제 API 구현

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/domain/common/entity/BaseEntity.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/common/entity/BaseEntity.kt
@@ -23,11 +23,11 @@ abstract class BaseEntity {
     lateinit var createdAt: LocalDateTime
         protected set
 
-    @CreatedBy
-    @Column(name = "created_by", nullable = false, updatable = false, length = 50)
-    @Comment("등록자")
-    lateinit var createdBy: String
-        protected set
+//    @CreatedBy
+//    @Column(name = "created_by", nullable = false, updatable = false, length = 50)
+//    @Comment("등록자")
+//    lateinit var createdBy: String
+//        protected set TODO: 인증/인가 구현 후 주석 해제
 
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false, columnDefinition = "DATETIME")
@@ -36,11 +36,11 @@ abstract class BaseEntity {
     lateinit var updatedAt: LocalDateTime
         protected set
 
-    @LastModifiedBy
-    @Column(name = "updated_by", nullable = false, length = 50)
-    @Comment("수정자")
-    lateinit var updatedBy: String
-        protected set
+//    @LastModifiedBy
+//    @Column(name = "updated_by", nullable = false, length = 50)
+//    @Comment("수정자")
+//    lateinit var updatedBy: String
+//        protected set TODO: 인증/인가 구현 후 주석 해제
 
     @Column(name = "deleted_at", insertable = false, updatable = false, columnDefinition = "DATETIME")
     @Comment("삭제일자")

--- a/src/main/kotlin/org/appjam/smashing/domain/game/entity/Game.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/entity/Game.kt
@@ -1,8 +1,21 @@
-package org.appjam.smashing.domain.matching.entity
+package org.appjam.smashing.domain.game.entity
 
 import io.hypersistence.utils.hibernate.id.Tsid
-import jakarta.persistence.*
+import jakarta.persistence.Column
+import jakarta.persistence.ConstraintMode
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
 import org.appjam.smashing.domain.common.entity.BaseEntity
+import org.appjam.smashing.domain.matching.entity.Matching
 import org.appjam.smashing.domain.matching.enums.GameResultStatus
 import org.appjam.smashing.domain.sport.entity.Sport
 import org.appjam.smashing.domain.user.entity.User
@@ -85,4 +98,15 @@ class Game(
     )
     @Comment("패자 유저 IDX(확정 시)")
     val loser: User? = null,
-) : BaseEntity()
+) : BaseEntity() {
+
+    companion object {
+        fun createFromMatching(
+            matching: Matching
+        ) = Game(
+                resultStatus = GameResultStatus.PENDING_RESULT,
+                matching = matching,
+                sport = matching.sport,
+            )
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/game/entity/GameResultSubmission.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/entity/GameResultSubmission.kt
@@ -1,7 +1,18 @@
-package org.appjam.smashing.domain.matching.entity
+package org.appjam.smashing.domain.game.entity
 
 import io.hypersistence.utils.hibernate.id.Tsid
-import jakarta.persistence.*
+import jakarta.persistence.Column
+import jakarta.persistence.ConstraintMode
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
 import org.appjam.smashing.domain.common.entity.BaseEntity
 import org.appjam.smashing.domain.matching.enums.RejectReason
 import org.appjam.smashing.domain.matching.enums.SubmissionStatus

--- a/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepository.kt
@@ -2,6 +2,9 @@ package org.appjam.smashing.domain.game.repository
 
 import org.appjam.smashing.domain.game.entity.Game
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.LocalDateTime
 
 interface GameRepository : JpaRepository<Game, String> {
     fun existsByMatchingId(
@@ -11,4 +14,24 @@ interface GameRepository : JpaRepository<Game, String> {
     fun findByMatchingId(
         matchingId: String
     ): Game?
+
+    @Query(
+        value = """
+            select count(*)
+            from game g
+            join matching m on m.id = g.matching_id
+            where g.result_status = 'RESULT_CONFIRMED'
+            and g.confirmed_at >= :startAt
+            and (
+            (m.requester_user_id = :userA and m.receiver_user_id = :userB)
+         or (m.requester_user_id = :userB and m.receiver_user_id = :userA)
+          )
+      """,
+        nativeQuery = true
+    )
+    fun countTodayConfirmedGamesBetweenUsers(
+        @Param("startAt") startAt: LocalDateTime,
+        @Param("userA") userA: String,
+        @Param("userB") userB: String,
+    ): Long
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepository.kt
@@ -1,0 +1,14 @@
+package org.appjam.smashing.domain.game.repository
+
+import org.appjam.smashing.domain.game.entity.Game
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface GameRepository : JpaRepository<Game, String> {
+    fun existsByMatchingId(
+        matchingId: String
+    ): Boolean
+
+    fun findByMatchingId(
+        matchingId: String
+    ): Game?
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/controller/MatchingController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/controller/MatchingController.kt
@@ -61,4 +61,27 @@ class MatchingController(
 
         return ApiResponse.success()
     }
+
+    @Operation(
+        summary = "매칭 요청 거절 API",
+        description = """
+            수신자가 받은 매칭 요청을 거절합니다.
+            - REQUESTED 상태에서만 거절 가능
+            - 거절 시 soft delete 처리
+            - Notification 생성 없음
+            - requester에게 SSE(matching.updated: REJECTED) 전송
+        """
+    )
+    @PostMapping("/{matchingId}/reject")
+    fun rejectMatching(
+        @RequestHeader("userId") requesterUserId: String, // TODO: 인증/인가 회복시 @AuthenticationPrincipal 으로 변경
+        @PathVariable matchingId: String,
+    ): ResponseEntity<ApiResponse<Unit>> {
+        matchingService.rejectMatching(
+            receiverUserId = requesterUserId,
+            matchingId = matchingId,
+        )
+
+        return ApiResponse.success()
+    }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/controller/MatchingController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/controller/MatchingController.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.appjam.smashing.domain.matching.service.MatchingService
 import org.appjam.smashing.global.common.dto.ApiResponse
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestHeader
@@ -79,6 +80,29 @@ class MatchingController(
     ): ResponseEntity<ApiResponse<Unit>> {
         matchingService.rejectMatching(
             receiverUserId = requesterUserId,
+            matchingId = matchingId,
+        )
+
+        return ApiResponse.success()
+    }
+
+    @Operation(
+        summary = "내가 보낸 매칭 요청 삭제 API",
+        description = """
+            내가 보낸 매칭 요청을 삭제합니다.
+            - REQUESTED 상태에서만 삭제 가능
+            - 삭제 시 soft delete 처리
+            - Notification 생성 없음
+            - receiver에게 SSE(matching.updated: CANCELLED) 전송
+        """
+    )
+    @DeleteMapping("/{matchingId}")
+    fun cancelMyMatchingRequest(
+        @RequestHeader("userId") requesterUserId: String, // TODO: 인증/인가 회복시 @AuthenticationPrincipal 으로 변경
+        @PathVariable matchingId: String,
+    ): ResponseEntity<ApiResponse<Unit>> {
+        matchingService.cancelMyMatchingRequest(
+            requesterUserId = requesterUserId,
             matchingId = matchingId,
         )
 

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/controller/MatchingController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/controller/MatchingController.kt
@@ -1,0 +1,44 @@
+package org.appjam.smashing.domain.matching.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.appjam.smashing.domain.matching.service.MatchingService
+import org.appjam.smashing.global.common.dto.ApiResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "Matching")
+@RestController
+@RequestMapping("/api/v1/matchings")
+class MatchingController(
+    private val matchingService: MatchingService,
+) {
+
+    @Operation(
+        summary = "매칭 신청 API",
+        description = """
+            상대 스포츠 프로필(receiverProfileId)에 대해 매칭을 신청합니다.
+            - 인증된 사용자 기준으로 매칭 요청을 생성합니다.
+            - 동일 유저 간 하루 최대 3회 신청 가능합니다.
+            - 성공 시 상대 유저에게 알림 및 SSE 이벤트가 전송됩니다.
+        """
+    )
+    @PostMapping("/profiles/{receiverProfileId}")
+    fun requestMatching(
+        // @AuthenticationPrincipal principal: CustomUserDetails, TODO: 인증/인가 회복시 주석 해제
+        @RequestHeader("userId") requesterUserId: String,
+        @PathVariable receiverProfileId: String,
+    ): ResponseEntity<ApiResponse<Unit>> {
+        matchingService.requestMatching(
+            // requesterUserId = principal.username, TODO: 인증/인가 회복시 주석 해제
+            requesterUserId = requesterUserId,
+            receiverProfileId = receiverProfileId,
+        )
+
+        return ApiResponse.success()
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/controller/MatchingController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/controller/MatchingController.kt
@@ -41,4 +41,24 @@ class MatchingController(
 
         return ApiResponse.success()
     }
+
+    @Operation(
+        summary = "매칭 요청 수락 API",
+        description = """
+            매칭 요청(matchingId)을 수락합니다.
+            - 성공 시 상대(requester)에게 알림 생성 + SSE 이벤트가 전송됩니다.
+        """
+    )
+    @PostMapping("/{matchingId}/accept")
+    fun acceptMatching(
+        @RequestHeader("userId") requesterUserId: String, // TODO: 인증/인가 회복시 @AuthenticationPrincipal 으로 변경
+        @PathVariable matchingId: String,
+    ): ResponseEntity<ApiResponse<Unit>> {
+        matchingService.acceptMatching(
+            receiverUserId = requesterUserId,
+            matchingId = matchingId,
+        )
+
+        return ApiResponse.success()
+    }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/entity/LpHistory.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/entity/LpHistory.kt
@@ -3,6 +3,7 @@ package org.appjam.smashing.domain.matching.entity
 import io.hypersistence.utils.hibernate.id.Tsid
 import jakarta.persistence.*
 import org.appjam.smashing.domain.common.entity.BaseEntity
+import org.appjam.smashing.domain.game.entity.Game
 import org.appjam.smashing.domain.user.entity.UserSportProfile
 import org.hibernate.annotations.Comment
 import org.hibernate.annotations.SQLDelete

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/entity/Matching.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/entity/Matching.kt
@@ -96,4 +96,11 @@ class Matching(
         status = MatchingStatus.REJECTED
         respondedAt = now
     }
+
+    fun cancel(
+        now: LocalDateTime
+    ) {
+        status = MatchingStatus.CANCELLED
+        respondedAt = now
+    }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/entity/Matching.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/entity/Matching.kt
@@ -89,4 +89,11 @@ class Matching(
         respondedAt = now
         confirmedAt = now
     }
+
+    fun reject(
+        now: LocalDateTime
+    ) {
+        status = MatchingStatus.REJECTED
+        respondedAt = now
+    }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/entity/Matching.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/entity/Matching.kt
@@ -68,4 +68,18 @@ class Matching(
     )
     @Comment("스포츠 IDX")
     val sport: Sport,
-) : BaseEntity()
+) : BaseEntity() {
+
+    companion object {
+        fun createRequested(
+            requester: User,
+            receiver: User,
+            sport: Sport,
+        ): Matching = Matching(
+            status = MatchingStatus.REQUESTED,
+            requester = requester,
+            receiver = receiver,
+            sport = sport,
+        )
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/entity/Matching.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/entity/Matching.kt
@@ -32,15 +32,15 @@ class Matching(
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, columnDefinition = "VARCHAR(30)")
     @Comment("매칭 상태")
-    val status: MatchingStatus,
+    var status: MatchingStatus = MatchingStatus.REQUESTED,
 
     @Column
     @Comment("응답 시각")
-    val respondedAt: LocalDateTime? = null,
+    var respondedAt: LocalDateTime? = null,
 
     @Column
     @Comment("매칭 확정 시각(ACCEPTED 시)")
-    val confirmedAt: LocalDateTime? = null,
+    var confirmedAt: LocalDateTime? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(
@@ -76,10 +76,17 @@ class Matching(
             receiver: User,
             sport: Sport,
         ): Matching = Matching(
-            status = MatchingStatus.REQUESTED,
             requester = requester,
             receiver = receiver,
             sport = sport,
         )
+    }
+
+    fun accept(
+        now: LocalDateTime
+    ) {
+        status = MatchingStatus.ACCEPTED
+        respondedAt = now
+        confirmedAt = now
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/enums/MatchingStatus.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/enums/MatchingStatus.kt
@@ -1,5 +1,9 @@
 package org.appjam.smashing.domain.matching.enums
 
 enum class MatchingStatus {
-    REQUESTED, ACCEPTED, REJECTED, COMPLETED
+    REQUESTED,       // 매칭 요청
+    ACCEPTED,        // 매칭 수락
+    REJECTED,        // 매칭 거절
+    CANCELLED,       // 매칭 요청 삭제
+    COMPLETED        // 매칭 확정
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepository.kt
@@ -24,4 +24,18 @@ interface MatchingRepository : JpaRepository<Matching, String> {
         userB: String,
         startAt: LocalDateTime,
     ): Long
+
+    @Query(
+        """
+        select m
+          from Matching m
+          join fetch m.requester
+          join fetch m.receiver
+          join fetch m.sport
+         where m.id = :matchingId
+        """
+    )
+    fun findByIdFetchAll(
+        matchingId: String
+    ): Matching?
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepository.kt
@@ -1,0 +1,27 @@
+package org.appjam.smashing.domain.matching.repository
+
+import org.appjam.smashing.domain.matching.entity.Matching
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import java.time.LocalDateTime
+
+interface MatchingRepository : JpaRepository<Matching, String> {
+
+    @Query(
+        value = """
+        select count(*)
+          from matching m
+         where (
+                (m.requester_user_id = :userA and m.receiver_user_id = :userB)
+             or (m.requester_user_id = :userB and m.receiver_user_id = :userA)
+         )
+           and m.created_at >= :startAt
+        """,
+        nativeQuery = true
+    )
+    fun countTodayBetweenUsersIncludingDeleted(
+        userA: String,
+        userB: String,
+        startAt: LocalDateTime,
+    ): Long
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepository.kt
@@ -8,24 +8,6 @@ import java.time.LocalDateTime
 interface MatchingRepository : JpaRepository<Matching, String> {
 
     @Query(
-        value = """
-        select count(*)
-          from matching m
-         where (
-                (m.requester_user_id = :userA and m.receiver_user_id = :userB)
-             or (m.requester_user_id = :userB and m.receiver_user_id = :userA)
-         )
-           and m.created_at >= :startAt
-        """,
-        nativeQuery = true
-    )
-    fun countTodayBetweenUsersIncludingDeleted(
-        userA: String,
-        userB: String,
-        startAt: LocalDateTime,
-    ): Long
-
-    @Query(
         """
         select m
           from Matching m

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
@@ -182,6 +182,30 @@ class MatchingService(
         )
     }
 
+    @Transactional
+    fun cancelMyMatchingRequest(
+        requesterUserId: String,
+        matchingId: String,
+    ) {
+        val matching = matchingRepository.findByIdFetchAll(matchingId)
+            ?: throw CustomException(ErrorCode.MATCHING_NOT_FOUND)
+
+        validateCancellableByRequester(matching, requesterUserId)
+
+        // 상태 변경
+        matching.cancel(LocalDateTime.now(DEFAULT_ZONE_ID))
+        matchingRepository.flush()
+
+        // soft delete
+        matchingRepository.delete(matching)
+
+        // SSE 이벤트 발행
+        publishMatchingUpdatedCancelled(
+            receiverUserId = matching.receiver.id!!,
+            matchingId = matchingId,
+        )
+    }
+
     private fun findReceiverProfile(receiverProfileId: String): UserSportProfile = userSportProfileRepository.findByIdFetchAll(receiverProfileId)
         ?: throw CustomException(ErrorCode.MATCHING_RECEIVER_PROFILE_NOT_FOUND)
 
@@ -226,6 +250,21 @@ class MatchingService(
         }
 
         // REQUESTED 상태만 거절 가능
+        if (matching.status != MatchingStatus.REQUESTED) {
+            throw CustomException(ErrorCode.MATCHING_ALREADY_RESPONDED)
+        }
+    }
+
+    private fun validateCancellableByRequester(
+        matching: Matching,
+        requesterUserId: String,
+    ) {
+        // requester만 삭제 가능
+        if (matching.requester.id!! != requesterUserId) {
+            throw CustomException(ErrorCode.MATCHING_FORBIDDEN)
+        }
+
+        // REQUESTED 상태만 삭제 가능
         if (matching.status != MatchingStatus.REQUESTED) {
             throw CustomException(ErrorCode.MATCHING_ALREADY_RESPONDED)
         }
@@ -334,6 +373,20 @@ class MatchingService(
             payload = MatchingUpdatedPayload(
                 matchingId = matchingId,
                 status = MatchingUpdateStatus.REJECTED,
+            )
+        )
+    }
+
+    private fun publishMatchingUpdatedCancelled(
+        receiverUserId: String,
+        matchingId: String,
+    ) {
+        outboxEventPublisher.publish(
+            userId = receiverUserId,
+            eventType = SseEventType.MATCHING_UPDATED,
+            payload = MatchingUpdatedPayload(
+                matchingId = matchingId,
+                status = MatchingUpdateStatus.CANCELLED,
             )
         )
     }

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
@@ -53,7 +53,7 @@ class MatchingService(
         val sportId = receiverProfile.sport.id ?: throw CustomException(ErrorCode.BAD_REQUEST)
         val requesterProfile = findRequesterProfileBySport(requesterUserId, sportId)
 
-        // 하루 (00:00 ~) 최대 3회 매칭 요청 가능
+        // 하루 (00:00 ~) 최대 3회 게임 가능
         validateDailyLimit(
             requesterUserId,
             receiverProfile.user.id!!
@@ -115,7 +115,6 @@ class MatchingService(
 
         // 수락 가능 여부 검증
         validateAcceptable(matching, receiverUserId)
-        // TODO: 매칭 3회 제한 등 제약 기획 확정되면 추가 필요
 
         // 매칭 수락 처리
         matching.accept(LocalDateTime.now(DEFAULT_ZONE_ID)) // TODO: 인증 붙으면 receiver 타임존으로 교체
@@ -221,21 +220,22 @@ class MatchingService(
         }
     }
 
-    // TODO: 현재 3회 매칭 제한 기획 제대로 안나옴. 기획 확정 후 수정 필요
-    private fun validateDailyLimit(requesterUserId: String, receiverUserId: String) {
-        // val zoneId = SecurityUtils.currentZoneId() TODO: 인증 붙이고 해제
-        val zoneId = ZoneId.of("Asia/Seoul")
-
-        val now = LocalDateTime.now(zoneId)
+    private fun validateDailyLimit(
+        requesterUserId: String,
+        receiverUserId: String
+    ) {
+        val now = LocalDateTime.now(DEFAULT_ZONE_ID)
         val startOfDay = now.toLocalDate().atStartOfDay()
 
-        val todayCount = matchingRepository.countTodayBetweenUsersIncludingDeleted(
+        // 하루 확정 게임 갯수 조회
+        val todayConfirmedGames = gameRepository.countTodayConfirmedGamesBetweenUsers(
+            startAt = startOfDay,
             userA = requesterUserId,
             userB = receiverUserId,
-            startAt = startOfDay,
         )
 
-        if (todayCount >= 3L) {
+        // 하루 최대 3회 제한
+        if (todayConfirmedGames >= 3L) {
             throw CustomException(ErrorCode.MATCHING_DAILY_LIMIT_EXCEEDED)
         }
     }

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
@@ -6,6 +6,7 @@ import org.appjam.smashing.domain.notification.enums.NotificationType
 import org.appjam.smashing.domain.notification.service.NotificationService
 import org.appjam.smashing.domain.outbox.components.OutboxEventPublisher
 import org.appjam.smashing.domain.outbox.dto.MatchingReceivedPayload
+import org.appjam.smashing.domain.outbox.dto.MatchingRequestNotificationCreatedPayload
 import org.appjam.smashing.domain.outbox.dto.NotificationCreatedPayload
 import org.appjam.smashing.domain.outbox.enums.SseEventType
 import org.appjam.smashing.domain.review.repository.GameReviewRepository
@@ -75,15 +76,20 @@ class MatchingService(
         publishMatchingReceived(
             receiverUserId = receiverProfile.user.id!!,
             matchingId = matchingId,
+            sportId = sportId,
+            receiverProfileId = receiverProfileId,
             requesterProfile = requesterProfile,
             reviewCount = reviewCount,
         )
 
         // 알림 생성 이벤트 발행
-        publishNotificationCreated(
+        publishMatchingRequestNotificationCreated(
             receiverUserId = receiverProfile.user.id!!,
             notificationId = notificationId,
             matchingId = matchingId,
+            sportId = sportId,
+            receiverProfileId = receiverProfileId,
+            requesterProfile = requesterProfile,
         )
     }
 
@@ -146,6 +152,8 @@ class MatchingService(
     private fun publishMatchingReceived(
         receiverUserId: String,
         matchingId: String,
+        sportId: Long,
+        receiverProfileId: String,
         requesterProfile: UserSportProfile,
         reviewCount: Long,
     ) {
@@ -154,11 +162,13 @@ class MatchingService(
             eventType = SseEventType.MATCHING_RECEIVED,
             payload = MatchingReceivedPayload(
                 matchingId = matchingId,
+                sportId = sportId,
+                receiverProfileId = receiverProfileId,
                 requester = MatchingReceivedPayload.MatchingRequesterSummary(
                     userId = requesterProfile.user.id!!,
                     nickname = requesterProfile.user.nickname,
                     gender = requesterProfile.user.gender,
-                    tierName = requesterProfile.tier.name,
+                    tierId = requesterProfile.tier.id!!,
                     wins = requesterProfile.wins,
                     losses = requesterProfile.losses,
                     reviewCount = reviewCount,
@@ -167,18 +177,28 @@ class MatchingService(
         )
     }
 
-    private fun publishNotificationCreated(
+    private fun publishMatchingRequestNotificationCreated(
         receiverUserId: String,
         notificationId: String,
         matchingId: String,
+        sportId: Long,
+        receiverProfileId: String,
+        requesterProfile: UserSportProfile,
     ) {
         outboxEventPublisher.publish(
             userId = receiverUserId,
-            eventType = SseEventType.NOTIFICATION_CREATED,
-            payload = NotificationCreatedPayload(
+            eventType = SseEventType.MATCHING_REQUEST_NOTIFICATION_CREATED,
+            payload = MatchingRequestNotificationCreatedPayload(
                 notificationId = notificationId,
                 notificationType = NotificationType.MATCHING_REQUESTED,
-                targetId = matchingId,
+                matchingId = matchingId,
+                sportId = sportId,
+                receiverProfileId = receiverProfileId,
+                requester = MatchingRequestNotificationCreatedPayload.RequesterSummary(
+                    userId = requesterProfile.user.id!!,
+                    nickname = requesterProfile.user.nickname,
+                    tierId = requesterProfile.tier.id!!,
+                )
             )
         )
     }

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
@@ -1,0 +1,185 @@
+package org.appjam.smashing.domain.matching.service
+
+import org.appjam.smashing.domain.matching.entity.Matching
+import org.appjam.smashing.domain.matching.repository.MatchingRepository
+import org.appjam.smashing.domain.notification.enums.NotificationType
+import org.appjam.smashing.domain.notification.service.NotificationService
+import org.appjam.smashing.domain.outbox.components.OutboxEventPublisher
+import org.appjam.smashing.domain.outbox.dto.MatchingReceivedPayload
+import org.appjam.smashing.domain.outbox.dto.NotificationCreatedPayload
+import org.appjam.smashing.domain.outbox.enums.SseEventType
+import org.appjam.smashing.domain.review.repository.GameReviewRepository
+import org.appjam.smashing.domain.user.entity.User
+import org.appjam.smashing.domain.user.entity.UserSportProfile
+import org.appjam.smashing.domain.user.repository.UserRepository
+import org.appjam.smashing.domain.user.repository.UserSportProfileRepository
+import org.appjam.smashing.global.exception.CustomException
+import org.appjam.smashing.global.exception.ErrorCode
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+@Service
+class MatchingService(
+    private val matchingRepository: MatchingRepository,
+    private val userRepository: UserRepository,
+    private val userSportProfileRepository: UserSportProfileRepository,
+    private val gameReviewRepository: GameReviewRepository,
+    private val notificationService: NotificationService,
+    private val outboxEventPublisher: OutboxEventPublisher,
+) {
+
+    @Transactional
+    fun requestMatching(
+        requesterUserId: String,
+        receiverProfileId: String,
+    ) {
+        val receiverProfile = findReceiverProfile(receiverProfileId)
+
+        // 자기 자신에게 매칭 요청 불가
+        validateNotSelf(requesterUserId, receiverProfile.user.id!!)
+
+        val requesterUser = findRequesterUser(requesterUserId)
+
+        val sportId = receiverProfile.sport.id ?: throw CustomException(ErrorCode.BAD_REQUEST)
+        val requesterProfile = findRequesterProfileBySport(requesterUserId, sportId)
+
+        // 하루 (00:00 ~) 최대 3회 매칭 요청 가능
+        validateDailyLimit(
+            requesterUserId,
+            receiverProfile.user.id!!
+        )
+
+        // 매칭 생성
+        val matchingId = createMatching(
+            requesterUser = requesterUser,
+            receiverUser = receiverProfile.user,
+            receiverProfile = receiverProfile,
+        )
+
+        // 신청자 해당 스포츠 리뷰 개수 조회
+        val reviewCount = countRequesterReviewsBySport(
+            requesterUserId = requesterUserId,
+            sportId = sportId,
+        )
+
+        // 알림 생성
+        val notificationId = notificationService.createMatchingRequested(
+            receiver = receiverProfile.user,
+            requesterProfile = requesterProfile,
+        )
+
+        // SSE 이벤트 발행
+        publishMatchingReceived(
+            receiverUserId = receiverProfile.user.id!!,
+            matchingId = matchingId,
+            requesterProfile = requesterProfile,
+            reviewCount = reviewCount,
+        )
+
+        // 알림 생성 이벤트 발행
+        publishNotificationCreated(
+            receiverUserId = receiverProfile.user.id!!,
+            notificationId = notificationId,
+            matchingId = matchingId,
+        )
+    }
+
+    private fun findReceiverProfile(receiverProfileId: String): UserSportProfile = userSportProfileRepository.findByIdFetchAll(receiverProfileId)
+        ?: throw CustomException(ErrorCode.MATCHING_RECEIVER_PROFILE_NOT_FOUND)
+
+    private fun findRequesterUser(requesterUserId: String): User = userRepository.findByIdOrNull(requesterUserId)
+            ?: throw CustomException(ErrorCode.MATCHING_REQUESTER_NOT_FOUND)
+
+    private fun findRequesterProfileBySport(requesterUserId: String, sportId: Long): UserSportProfile = userSportProfileRepository.findByUserIdAndSportIdFetch(requesterUserId, sportId)
+            ?: throw CustomException(ErrorCode.MATCHING_REQUESTER_NOT_FOUND)
+
+    private fun validateNotSelf(requesterUserId: String, receiverUserId: String) {
+        if (requesterUserId == receiverUserId) {
+            throw CustomException(ErrorCode.MATCHING_CANNOT_REQUEST_TO_SELF)
+        }
+    }
+
+    private fun validateDailyLimit(requesterUserId: String, receiverUserId: String) {
+        // val zoneId = SecurityUtils.currentZoneId() TODO: 인증 붙이고 해제
+        val zoneId = ZoneId.of("Asia/Seoul")
+
+        val now = LocalDateTime.now(zoneId)
+        val startOfDay = now.toLocalDate().atStartOfDay()
+
+        val todayCount = matchingRepository.countTodayBetweenUsersIncludingDeleted(
+            userA = requesterUserId,
+            userB = receiverUserId,
+            startAt = startOfDay,
+        )
+
+        if (todayCount >= 3L) {
+            throw CustomException(ErrorCode.MATCHING_DAILY_LIMIT_EXCEEDED)
+        }
+    }
+
+    private fun createMatching(
+        requesterUser: User,
+        receiverUser: User,
+        receiverProfile: UserSportProfile,
+    ): String {
+        val matching = matchingRepository.save(
+            Matching.createRequested(
+                requester = requesterUser,
+                receiver = receiverUser,
+                sport = receiverProfile.sport,
+            )
+        )
+        return requireNotNull(matching.id)
+    }
+
+    private fun countRequesterReviewsBySport(
+        requesterUserId: String,
+        sportId: Long,
+    ): Long = gameReviewRepository.countByRevieweeAndSport(
+            revieweeUserId = requesterUserId,
+            sportId = sportId,
+        )
+
+    private fun publishMatchingReceived(
+        receiverUserId: String,
+        matchingId: String,
+        requesterProfile: UserSportProfile,
+        reviewCount: Long,
+    ) {
+        outboxEventPublisher.publish(
+            userId = receiverUserId,
+            eventType = SseEventType.MATCHING_RECEIVED,
+            payload = MatchingReceivedPayload(
+                matchingId = matchingId,
+                requester = MatchingReceivedPayload.MatchingRequesterSummary(
+                    userId = requesterProfile.user.id!!,
+                    nickname = requesterProfile.user.nickname,
+                    gender = requesterProfile.user.gender,
+                    tierName = requesterProfile.tier.name,
+                    wins = requesterProfile.wins,
+                    losses = requesterProfile.losses,
+                    reviewCount = reviewCount,
+                )
+            )
+        )
+    }
+
+    private fun publishNotificationCreated(
+        receiverUserId: String,
+        notificationId: String,
+        matchingId: String,
+    ) {
+        outboxEventPublisher.publish(
+            userId = receiverUserId,
+            eventType = SseEventType.NOTIFICATION_CREATED,
+            payload = NotificationCreatedPayload(
+                notificationId = notificationId,
+                notificationType = NotificationType.MATCHING_REQUESTED,
+                targetId = matchingId,
+            )
+        )
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
@@ -1,13 +1,18 @@
 package org.appjam.smashing.domain.matching.service
 
+import org.appjam.smashing.domain.game.entity.Game
+import org.appjam.smashing.domain.game.repository.GameRepository
 import org.appjam.smashing.domain.matching.entity.Matching
+import org.appjam.smashing.domain.matching.enums.MatchingStatus
 import org.appjam.smashing.domain.matching.repository.MatchingRepository
 import org.appjam.smashing.domain.notification.enums.NotificationType
 import org.appjam.smashing.domain.notification.service.NotificationService
 import org.appjam.smashing.domain.outbox.components.OutboxEventPublisher
+import org.appjam.smashing.domain.outbox.dto.MatchingAcceptNotificationCreatedPayload
 import org.appjam.smashing.domain.outbox.dto.MatchingReceivedPayload
 import org.appjam.smashing.domain.outbox.dto.MatchingRequestNotificationCreatedPayload
-import org.appjam.smashing.domain.outbox.dto.NotificationCreatedPayload
+import org.appjam.smashing.domain.outbox.dto.MatchingUpdatedPayload
+import org.appjam.smashing.domain.outbox.enums.MatchingUpdateStatus
 import org.appjam.smashing.domain.outbox.enums.SseEventType
 import org.appjam.smashing.domain.review.repository.GameReviewRepository
 import org.appjam.smashing.domain.user.entity.User
@@ -27,6 +32,7 @@ class MatchingService(
     private val matchingRepository: MatchingRepository,
     private val userRepository: UserRepository,
     private val userSportProfileRepository: UserSportProfileRepository,
+    private val gameRepository: GameRepository,
     private val gameReviewRepository: GameReviewRepository,
     private val notificationService: NotificationService,
     private val outboxEventPublisher: OutboxEventPublisher,
@@ -67,10 +73,15 @@ class MatchingService(
         )
 
         // 알림 생성
-        val notificationId = notificationService.createMatchingRequested(
+        val savedNotification = notificationService.createMatchingRequested(
             receiver = receiverProfile.user,
             requesterProfile = requesterProfile,
         )
+
+        val notificationCreatedAt = savedNotification.createdAt
+            .atZone(DEFAULT_ZONE_ID)
+            .toOffsetDateTime()
+            .toString()
 
         // SSE 이벤트 발행
         publishMatchingReceived(
@@ -85,13 +96,68 @@ class MatchingService(
         // 알림 생성 이벤트 발행
         publishMatchingRequestNotificationCreated(
             receiverUserId = receiverProfile.user.id!!,
-            notificationId = notificationId,
+            notificationId = savedNotification.id!!,
+            notificationCreatedAt = notificationCreatedAt,
             matchingId = matchingId,
             sportId = sportId,
             receiverProfileId = receiverProfileId,
             requesterProfile = requesterProfile,
         )
     }
+
+    @Transactional
+    fun acceptMatching(
+        receiverUserId: String,
+        matchingId: String,
+    ) {
+        val matching = matchingRepository.findByIdFetchAll(matchingId)
+            ?: throw CustomException(ErrorCode.MATCHING_NOT_FOUND)
+
+        // 수락 가능 여부 검증
+        validateAcceptable(matching, receiverUserId)
+        // TODO: 매칭 3회 제한 등 제약 기획 확정되면 추가 필요
+
+        // 매칭 수락 처리
+        matching.accept(LocalDateTime.now(DEFAULT_ZONE_ID)) // TODO: 인증 붙으면 receiver 타임존으로 교체
+
+        // 게임 엔티티 생성 (중복 방지)
+        if (!gameRepository.existsByMatchingId(matchingId)) {
+            gameRepository.save(Game.createFromMatching(matching))
+        }
+
+        val receiverProfile = findUserProfileBySport(receiverUserId, matching.sport.id!!)
+
+        // 알림 생성
+        val savedNotification = notificationService.createMatchingAccepted(
+            receiver = matching.requester,
+            acceptorProfile = receiverProfile,
+        )
+
+        // 알림 생성 시간 OffsetDateTime으로 변환
+        val notificationCreatedAt = savedNotification.createdAt
+            .atZone(DEFAULT_ZONE_ID)
+            .toOffsetDateTime()
+            .toString()
+
+        // SSE 이벤트 발행
+        publishMatchingUpdatedAccepted(
+            requesterUserId = matching.requester.id!!,
+            matchingId = matchingId,
+        )
+
+        // 알림 생성 이벤트 발행
+        publishMatchingAcceptNotificationCreated(
+            requesterUserId = matching.requester.id!!,
+            notificationId = savedNotification.id!!,
+            notificationCreatedAt = notificationCreatedAt,
+            matchingId = matchingId,
+            sportId = matching.sport.id!!,
+            receiverProfileId = receiverProfile.id!!,
+            receiverUserId = receiverUserId,
+            receiverProfile = receiverProfile,
+        )
+    }
+
 
     private fun findReceiverProfile(receiverProfileId: String): UserSportProfile = userSportProfileRepository.findByIdFetchAll(receiverProfileId)
         ?: throw CustomException(ErrorCode.MATCHING_RECEIVER_PROFILE_NOT_FOUND)
@@ -108,6 +174,7 @@ class MatchingService(
         }
     }
 
+    // TODO: 현재 3회 매칭 제한 기획 제대로 안나옴. 기획 확정 후 수정 필요
     private fun validateDailyLimit(requesterUserId: String, receiverUserId: String) {
         // val zoneId = SecurityUtils.currentZoneId() TODO: 인증 붙이고 해제
         val zoneId = ZoneId.of("Asia/Seoul")
@@ -177,9 +244,24 @@ class MatchingService(
         )
     }
 
+    private fun publishMatchingUpdatedAccepted(
+        requesterUserId: String,
+        matchingId: String,
+    ) {
+        outboxEventPublisher.publish(
+            userId = requesterUserId,
+            eventType = SseEventType.MATCHING_UPDATED,
+            payload = MatchingUpdatedPayload(
+                matchingId = matchingId,
+                status = MatchingUpdateStatus.ACCEPTED,
+            )
+        )
+    }
+
     private fun publishMatchingRequestNotificationCreated(
         receiverUserId: String,
         notificationId: String,
+        notificationCreatedAt: String,
         matchingId: String,
         sportId: Long,
         receiverProfileId: String,
@@ -191,6 +273,7 @@ class MatchingService(
             payload = MatchingRequestNotificationCreatedPayload(
                 notificationId = notificationId,
                 notificationType = NotificationType.MATCHING_REQUESTED,
+                notificationCreatedAt = notificationCreatedAt,
                 matchingId = matchingId,
                 sportId = sportId,
                 receiverProfileId = receiverProfileId,
@@ -201,5 +284,59 @@ class MatchingService(
                 )
             )
         )
+    }
+
+    private fun validateAcceptable(
+        matching: Matching,
+        receiverUserId: String
+    ) {
+        // receiver만 수락 가능
+        if (matching.receiver.id!! != receiverUserId) {
+            throw CustomException(ErrorCode.MATCHING_FORBIDDEN)
+        }
+
+        // REQUESTED 상태만 수락 가능
+        if (matching.status != MatchingStatus.REQUESTED) {
+            throw CustomException(ErrorCode.MATCHING_ALREADY_RESPONDED)
+        }
+    }
+
+    private fun findUserProfileBySport(
+        userId: String,
+        sportId: Long
+    ): UserSportProfile = userSportProfileRepository.findByUserIdAndSportIdFetch(userId, sportId)
+            ?: throw CustomException(ErrorCode.MATCHING_RECEIVER_USER_NOT_FOUND)
+
+    private fun publishMatchingAcceptNotificationCreated(
+        requesterUserId: String,
+        notificationId: String,
+        notificationCreatedAt: String,
+        matchingId: String,
+        sportId: Long,
+        receiverProfileId: String,
+        receiverUserId: String,
+        receiverProfile: UserSportProfile,
+    ) {
+        outboxEventPublisher.publish(
+            userId = requesterUserId,
+            eventType = SseEventType.MATCHING_ACCEPT_NOTIFICATION_CREATED,
+            payload = MatchingAcceptNotificationCreatedPayload(
+                notificationId = notificationId,
+                notificationType = NotificationType.MATCHING_ACCEPTED,
+                notificationCreatedAt = notificationCreatedAt,
+                matchingId = matchingId,
+                sportId = sportId,
+                receiverProfileId = receiverProfileId,
+                acceptor = MatchingAcceptNotificationCreatedPayload.AcceptorSummary(
+                    userId = receiverUserId,
+                    nickname = receiverProfile.user.nickname,
+                    tierId = receiverProfile.tier.id!!,
+                )
+            )
+        )
+    }
+
+    companion object {
+        private val DEFAULT_ZONE_ID = ZoneId.of("Asia/Seoul")
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
@@ -158,6 +158,29 @@ class MatchingService(
         )
     }
 
+    @Transactional
+    fun rejectMatching(
+        receiverUserId: String,
+        matchingId: String,
+    ) {
+        val matching = matchingRepository.findByIdFetchAll(matchingId)
+            ?: throw CustomException(ErrorCode.MATCHING_NOT_FOUND)
+
+        validateRejectable(matching, receiverUserId)
+
+        // 상태 변경
+        matching.reject(LocalDateTime.now(DEFAULT_ZONE_ID))
+        matchingRepository.flush()
+
+        // soft delete
+        matchingRepository.delete(matching)
+
+        // SSE 이벤트 발행
+        publishMatchingUpdatedRejected(
+            requesterUserId = matching.requester.id!!,
+            matchingId = matchingId,
+        )
+    }
 
     private fun findReceiverProfile(receiverProfileId: String): UserSportProfile = userSportProfileRepository.findByIdFetchAll(receiverProfileId)
         ?: throw CustomException(ErrorCode.MATCHING_RECEIVER_PROFILE_NOT_FOUND)
@@ -190,6 +213,21 @@ class MatchingService(
 
         if (todayCount >= 3L) {
             throw CustomException(ErrorCode.MATCHING_DAILY_LIMIT_EXCEEDED)
+        }
+    }
+
+    private fun validateRejectable(
+        matching: Matching,
+        receiverUserId: String,
+    ) {
+        // receiver만 거절 가능
+        if (matching.receiver.id!! != receiverUserId) {
+            throw CustomException(ErrorCode.MATCHING_FORBIDDEN)
+        }
+
+        // REQUESTED 상태만 거절 가능
+        if (matching.status != MatchingStatus.REQUESTED) {
+            throw CustomException(ErrorCode.MATCHING_ALREADY_RESPONDED)
         }
     }
 
@@ -282,6 +320,20 @@ class MatchingService(
                     nickname = requesterProfile.user.nickname,
                     tierId = requesterProfile.tier.id!!,
                 )
+            )
+        )
+    }
+
+    private fun publishMatchingUpdatedRejected(
+        requesterUserId: String,
+        matchingId: String,
+    ) {
+        outboxEventPublisher.publish(
+            userId = requesterUserId,
+            eventType = SseEventType.MATCHING_UPDATED,
+            payload = MatchingUpdatedPayload(
+                matchingId = matchingId,
+                status = MatchingUpdateStatus.REJECTED,
             )
         )
     }

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/entity/Notification.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/entity/Notification.kt
@@ -4,6 +4,7 @@ import io.hypersistence.utils.hibernate.id.Tsid
 import jakarta.persistence.*
 import org.appjam.smashing.domain.common.entity.BaseEntity
 import org.appjam.smashing.domain.user.entity.User
+import org.appjam.smashing.domain.user.entity.UserSportProfile
 import org.hibernate.annotations.Comment
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
@@ -54,4 +55,20 @@ class Notification(
     )
     @Comment("템플릿 IDX")
     val notificationTemplate: NotificationTemplate,
-) : BaseEntity()
+) : BaseEntity() {
+
+    companion object {
+        fun createMatchingRequested(
+            receiver: User,
+            template: NotificationTemplate,
+            requesterProfile: UserSportProfile,
+        ): Notification =
+            Notification(
+                params = """{"requesterNickname":"${requesterProfile.user.nickname}","requesterTierName":"${requesterProfile.tier.name}"}""",
+                isRead = false,
+                linkUrl = "/api/v1/users/me/matchings/received",
+                user = receiver,
+                notificationTemplate = template,
+            )
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/entity/Notification.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/entity/Notification.kt
@@ -62,11 +62,22 @@ class Notification(
             receiver: User,
             template: NotificationTemplate,
             requesterProfile: UserSportProfile,
-        ): Notification =
-            Notification(
+        ) = Notification(
                 params = """{"requesterNickname":"${requesterProfile.user.nickname}","requesterTierName":"${requesterProfile.tier.name}"}""",
                 isRead = false,
                 linkUrl = "/api/v1/users/me/matchings/received",
+                user = receiver,
+                notificationTemplate = template,
+            )
+
+        fun createMatchingRequestAccepted(
+            receiver: User,
+            template: NotificationTemplate,
+            acceptorProfile: UserSportProfile,
+        ) = Notification(
+                params = """{"acceptorNickname":"${acceptorProfile.user.nickname}","acceptorTierId":${acceptorProfile.tier.id!!}}""",
+                isRead = false,
+                linkUrl = "/api/v1/users/me/matchings/accepted/pending-result",
                 user = receiver,
                 notificationTemplate = template,
             )

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/repository/NotificationRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/repository/NotificationRepository.kt
@@ -1,0 +1,6 @@
+package org.appjam.smashing.domain.notification.repository
+
+import org.appjam.smashing.domain.notification.entity.Notification
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface NotificationRepository : JpaRepository<Notification, String>

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/repository/NotificationTemplateRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/repository/NotificationTemplateRepository.kt
@@ -1,0 +1,9 @@
+package org.appjam.smashing.domain.notification.repository
+
+import org.appjam.smashing.domain.notification.entity.NotificationTemplate
+import org.appjam.smashing.domain.notification.enums.NotificationType
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface NotificationTemplateRepository : JpaRepository<NotificationTemplate, Long> {
+    fun findByType(type: NotificationType): NotificationTemplate?
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/service/NotificationService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/service/NotificationService.kt
@@ -1,0 +1,36 @@
+package org.appjam.smashing.domain.notification.service
+
+import org.appjam.smashing.domain.notification.entity.Notification
+import org.appjam.smashing.domain.notification.enums.NotificationType
+import org.appjam.smashing.domain.notification.repository.NotificationRepository
+import org.appjam.smashing.domain.notification.repository.NotificationTemplateRepository
+import org.appjam.smashing.domain.user.entity.User
+import org.appjam.smashing.domain.user.entity.UserSportProfile
+import org.appjam.smashing.global.exception.CustomException
+import org.appjam.smashing.global.exception.ErrorCode
+import org.springframework.stereotype.Service
+
+@Service
+class NotificationService(
+    private val notificationRepository: NotificationRepository,
+    private val notificationTemplateRepository: NotificationTemplateRepository,
+) {
+
+    fun createMatchingRequested(
+        receiver: User,
+        requesterProfile: UserSportProfile,
+    ): String {
+        val template = notificationTemplateRepository.findByType(NotificationType.MATCHING_REQUESTED)
+            ?: throw CustomException(ErrorCode.NOTIFICATION_TEMPLATE_NOT_FOUND)
+
+        val notification = notificationRepository.save(
+            Notification.createMatchingRequested(
+                receiver = receiver,
+                template = template,
+                requesterProfile = requesterProfile,
+            )
+        )
+
+        return requireNotNull(notification.id)
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/service/NotificationService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/service/NotificationService.kt
@@ -19,18 +19,32 @@ class NotificationService(
     fun createMatchingRequested(
         receiver: User,
         requesterProfile: UserSportProfile,
-    ): String {
+    ): Notification {
         val template = notificationTemplateRepository.findByType(NotificationType.MATCHING_REQUESTED)
             ?: throw CustomException(ErrorCode.NOTIFICATION_TEMPLATE_NOT_FOUND)
 
-        val notification = notificationRepository.save(
+        return notificationRepository.save(
             Notification.createMatchingRequested(
                 receiver = receiver,
                 template = template,
                 requesterProfile = requesterProfile,
             )
         )
+    }
 
-        return requireNotNull(notification.id)
+    fun createMatchingAccepted(
+        receiver: User,
+        acceptorProfile: UserSportProfile,
+    ): Notification {
+        val template = notificationTemplateRepository.findByType(NotificationType.MATCHING_ACCEPTED)
+            ?: throw CustomException(ErrorCode.NOTIFICATION_TEMPLATE_NOT_FOUND)
+
+        return notificationRepository.save(
+            Notification.createMatchingRequestAccepted(
+                receiver = receiver,
+                template = template,
+                acceptorProfile = acceptorProfile,
+            )
+        )
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/outbox/dto/SsePayload.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/outbox/dto/SsePayload.kt
@@ -78,7 +78,7 @@ data class MatchingRequestNotificationCreatedPayload(
 
 /**
  * 매칭 수락 알림 생성
- * - 상대가 나에게 매칭을 신청한 순간 알림 생성
+ * - 상대가 나의 매칭을 수락한 순간 알림 생성
  */
 data class MatchingAcceptNotificationCreatedPayload(
     override val type: String = SseEventType.MATCHING_ACCEPT_NOTIFICATION_CREATED.eventName,

--- a/src/main/kotlin/org/appjam/smashing/domain/outbox/dto/SsePayload.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/outbox/dto/SsePayload.kt
@@ -62,6 +62,7 @@ data class MatchingRequestNotificationCreatedPayload(
     override val type: String = SseEventType.MATCHING_REQUEST_NOTIFICATION_CREATED.eventName,
     val notificationId: String,
     val notificationType: NotificationType,
+    val notificationCreatedAt: String,
     val matchingId: String,
     val sportId: Long,
     val receiverProfileId: String,
@@ -69,6 +70,28 @@ data class MatchingRequestNotificationCreatedPayload(
 ) : SsePayload {
 
     data class RequesterSummary(
+        val userId: String,
+        val nickname: String,
+        val tierId: Long,
+    )
+}
+
+/**
+ * 매칭 수락 알림 생성
+ * - 상대가 나에게 매칭을 신청한 순간 알림 생성
+ */
+data class MatchingAcceptNotificationCreatedPayload(
+    override val type: String = SseEventType.MATCHING_ACCEPT_NOTIFICATION_CREATED.eventName,
+    val notificationId: String,
+    val notificationType: NotificationType,
+    val notificationCreatedAt: String,
+    val matchingId: String,
+    val sportId: Long,
+    val receiverProfileId: String,
+    val acceptor: AcceptorSummary,
+) : SsePayload {
+
+    data class AcceptorSummary(
         val userId: String,
         val nickname: String,
         val tierId: Long,

--- a/src/main/kotlin/org/appjam/smashing/domain/outbox/dto/SsePayload.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/outbox/dto/SsePayload.kt
@@ -16,6 +16,8 @@ sealed interface SsePayload {
 data class MatchingReceivedPayload(
     override val type: String = SseEventType.MATCHING_RECEIVED.eventName,
     val matchingId: String,
+    val sportId: Long,
+    val receiverProfileId: String,
     val requester: MatchingRequesterSummary,
 ) : SsePayload {
 
@@ -23,7 +25,7 @@ data class MatchingReceivedPayload(
         val userId: String,
         val nickname: String,
         val gender: Gender,
-        val tierName: String,
+        val tierId: Long,
         val wins: Int,
         val losses: Int,
         val reviewCount: Long,
@@ -51,3 +53,24 @@ data class NotificationCreatedPayload(
     val notificationType: NotificationType,
     val targetId: String? = null,           // matchingId/gameId/reviewId 등
 ) : SsePayload
+
+/**
+ * 매칭 신청 알림 생성
+ * - 상대가 나에게 매칭을 신청한 순간 알림 생성
+ */
+data class MatchingRequestNotificationCreatedPayload(
+    override val type: String = SseEventType.MATCHING_REQUEST_NOTIFICATION_CREATED.eventName,
+    val notificationId: String,
+    val notificationType: NotificationType,
+    val matchingId: String,
+    val sportId: Long,
+    val receiverProfileId: String,
+    val requester: RequesterSummary,
+) : SsePayload {
+
+    data class RequesterSummary(
+        val userId: String,
+        val nickname: String,
+        val tierId: Long,
+    )
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/outbox/dto/SsePayload.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/outbox/dto/SsePayload.kt
@@ -3,6 +3,7 @@ package org.appjam.smashing.domain.outbox.dto
 import org.appjam.smashing.domain.notification.enums.NotificationType
 import org.appjam.smashing.domain.outbox.enums.MatchingUpdateStatus
 import org.appjam.smashing.domain.outbox.enums.SseEventType
+import org.appjam.smashing.domain.user.enums.Gender
 
 sealed interface SsePayload {
     val type: String
@@ -15,7 +16,19 @@ sealed interface SsePayload {
 data class MatchingReceivedPayload(
     override val type: String = SseEventType.MATCHING_RECEIVED.eventName,
     val matchingId: String,
-) : SsePayload
+    val requester: MatchingRequesterSummary,
+) : SsePayload {
+
+    data class MatchingRequesterSummary(
+        val userId: String,
+        val nickname: String,
+        val gender: Gender,
+        val tierName: String,
+        val wins: Int,
+        val losses: Int,
+        val reviewCount: Long,
+    )
+}
 
 /**
  * 매칭관리 - 보낸 요청 / 매칭확정 / 요청삭제

--- a/src/main/kotlin/org/appjam/smashing/domain/outbox/entity/OutboxEvent.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/outbox/entity/OutboxEvent.kt
@@ -28,7 +28,7 @@ class OutboxEvent(
     val userId: String,
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 30)
+    @Column(nullable = false, length = 100)
     @Comment("Outbox Event 타입")
     val eventType: SseEventType,
 

--- a/src/main/kotlin/org/appjam/smashing/domain/outbox/enums/SseEventType.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/outbox/enums/SseEventType.kt
@@ -14,4 +14,7 @@ enum class SseEventType(
 
     // 매칭 요청 알림 생성
     MATCHING_REQUEST_NOTIFICATION_CREATED("matching.request.notification.created"),
+
+    // 매칭 수락 알림 생성
+    MATCHING_ACCEPT_NOTIFICATION_CREATED("matching.accept.notification.created"),
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/outbox/enums/SseEventType.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/outbox/enums/SseEventType.kt
@@ -11,4 +11,7 @@ enum class SseEventType(
 
     // 알림 관련 생성 / 변경 사항
     NOTIFICATION_CREATED("notification.created"),
+
+    // 매칭 요청 알림 생성
+    MATCHING_REQUEST_NOTIFICATION_CREATED("matching.request.notification.created"),
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/review/entity/GameReview.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/review/entity/GameReview.kt
@@ -3,7 +3,7 @@ package org.appjam.smashing.domain.review.entity
 import io.hypersistence.utils.hibernate.id.Tsid
 import jakarta.persistence.*
 import org.appjam.smashing.domain.common.entity.BaseEntity
-import org.appjam.smashing.domain.matching.entity.Game
+import org.appjam.smashing.domain.game.entity.Game
 import org.appjam.smashing.domain.review.enums.*
 import org.appjam.smashing.domain.user.entity.User
 import org.hibernate.annotations.Comment

--- a/src/main/kotlin/org/appjam/smashing/domain/review/repository/GameReviewRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/review/repository/GameReviewRepository.kt
@@ -1,0 +1,22 @@
+package org.appjam.smashing.domain.review.repository
+
+import org.appjam.smashing.domain.review.entity.GameReview
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface GameReviewRepository : JpaRepository<GameReview, String> {
+
+    @Query(
+        """
+        select count(gr)
+          from GameReview gr
+          join gr.game g
+         where gr.reviewee.id = :revieweeUserId
+           and g.sport.id = :sportId
+        """
+    )
+    fun countByRevieweeAndSport(
+        revieweeUserId: String,
+        sportId: Long,
+    ): Long
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserRepository.kt
@@ -1,0 +1,6 @@
+package org.appjam.smashing.domain.user.repository
+
+import org.appjam.smashing.domain.user.entity.User
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface UserRepository : JpaRepository<User, String>

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
@@ -1,0 +1,38 @@
+package org.appjam.smashing.domain.user.repository
+
+import org.appjam.smashing.domain.user.entity.UserSportProfile
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface UserSportProfileRepository : JpaRepository<UserSportProfile, String> {
+
+    @Query(
+        """
+        select usp
+          from UserSportProfile usp
+          join fetch usp.user u
+          join fetch usp.tier t
+          join fetch usp.sport s
+         where u.id = :userId
+           and s.id = :sportId
+        """
+    )
+    fun findByUserIdAndSportIdFetch(
+        userId: String,
+        sportId: Long,
+    ): UserSportProfile?
+
+    @Query(
+        """
+    select usp
+      from UserSportProfile usp
+      join fetch usp.user
+      join fetch usp.sport
+      join fetch usp.tier
+     where usp.id = :profileId
+    """
+    )
+    fun findByIdFetchAll(
+        profileId: String,
+    ): UserSportProfile?
+}

--- a/src/main/kotlin/org/appjam/smashing/global/auth/jwt/components/JwtProvider.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/auth/jwt/components/JwtProvider.kt
@@ -4,7 +4,7 @@ import org.appjam.smashing.global.auth.jwt.components.JwtGenerator.Companion.ROL
 import org.appjam.smashing.global.auth.jwt.components.JwtGenerator.Companion.TYPE_KEY
 import org.appjam.smashing.global.auth.jwt.dto.TokenDto
 import org.appjam.smashing.global.auth.jwt.enums.TokenType
-import org.appjam.smashing.global.auth.security.CustomUserDetails
+import org.appjam.smashing.global.auth.security.data.CustomUserDetails
 import org.appjam.smashing.global.exception.CustomException
 import org.appjam.smashing.global.exception.ErrorCode
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
@@ -32,7 +32,10 @@ class JwtProvider(
         )
     }
 
-    fun getAuthentication(token: String): Authentication {
+    fun getAuthentication(
+        token: String,
+        timeZone: String
+    ): Authentication {
         val claims = jwtValidator.validateAndParseAccessToken(token)
 
         val roles = claims[ROLES_KEY] as? List<*> ?: throw CustomException(ErrorCode.INVALID_ACCESS_TOKEN_CLAIM)
@@ -49,7 +52,8 @@ class JwtProvider(
 
         val userDetails = CustomUserDetails(
             userId = subject,
-            authorities = authorities
+            authorities = authorities,
+            timeZone = timeZone
         )
 
         return UsernamePasswordAuthenticationToken(

--- a/src/main/kotlin/org/appjam/smashing/global/auth/jwt/filter/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/auth/jwt/filter/JwtAuthenticationFilter.kt
@@ -5,12 +5,15 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.appjam.smashing.global.auth.jwt.components.JwtProvider
 import org.appjam.smashing.global.auth.jwt.handler.JwtAuthenticationEntryPoint.Companion.EXCEPTION_KEY
+import org.appjam.smashing.global.config.TimeZoneProperties
 import org.springframework.http.HttpHeaders
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.filter.OncePerRequestFilter
+import java.time.ZoneId
 
 class JwtAuthenticationFilter(
-    private val jwtProvider: JwtProvider
+    private val jwtProvider: JwtProvider,
+    private val timeZoneProperties: TimeZoneProperties,
 ) : OncePerRequestFilter() {
 
     override fun doFilterInternal(
@@ -22,7 +25,8 @@ class JwtAuthenticationFilter(
 
         if (!token.isNullOrBlank()) {
             try {
-                val authentication = jwtProvider.getAuthentication(token)
+                val timeZone = resolveTimeZone(request)
+                val authentication = jwtProvider.getAuthentication(token, timeZone)
                 SecurityContextHolder.getContext().authentication = authentication
             } catch (e: Exception) {
                 SecurityContextHolder.clearContext()
@@ -44,7 +48,26 @@ class JwtAuthenticationFilter(
         }
     }
 
+    // TODO: DB UTC 변경시 추후 사용자 타임존 관련 처리 필요
+    private fun resolveTimeZone(
+        request: HttpServletRequest
+    ): String {
+        val timeZone = request.getHeader(TIME_ZONE_HEADER)?.trim()
+
+        if (timeZone.isNullOrBlank()) {
+            return timeZoneProperties.defaultTimeZone
+        }
+
+        return runCatching {
+            ZoneId.of(timeZone)
+            timeZone
+        }.getOrElse {
+            timeZoneProperties.defaultTimeZone
+        }
+    }
+
     companion object {
         private const val PREFIX = "Bearer "
+        private const val TIME_ZONE_HEADER = "Time-Zone"
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/global/auth/security/data/CustomUserDetails.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/auth/security/data/CustomUserDetails.kt
@@ -6,6 +6,7 @@ import org.springframework.security.core.userdetails.UserDetails
 class CustomUserDetails(
     private val userId: String,
     private val authorities: Collection<GrantedAuthority>,
+    private val timeZone: String,
 ) : UserDetails {
     override fun getAuthorities(): Collection<GrantedAuthority> = authorities
 
@@ -20,4 +21,6 @@ class CustomUserDetails(
     override fun isCredentialsNonExpired(): Boolean = true
 
     override fun isEnabled(): Boolean = true
+
+    fun getTimeZone(): String = timeZone
 }

--- a/src/main/kotlin/org/appjam/smashing/global/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/config/SecurityConfig.kt
@@ -22,6 +22,7 @@ class SecurityConfig(
     private val jwtProvider: JwtProvider,
     private val jwtAuthenticationEntryPoint: JwtAuthenticationEntryPoint,
     private val jwtAccessDeniedHandler: JwtAccessDeniedHandler,
+    private val timeZoneProperties: TimeZoneProperties,
 ) {
 
     @Bean
@@ -48,7 +49,7 @@ class SecurityConfig(
                 accessDeniedHandler = jwtAccessDeniedHandler
             }
 
-            addFilterBefore<UsernamePasswordAuthenticationFilter>(JwtAuthenticationFilter(jwtProvider))
+            addFilterBefore<UsernamePasswordAuthenticationFilter>(JwtAuthenticationFilter(jwtProvider, timeZoneProperties))
         }
 
         return http.build()

--- a/src/main/kotlin/org/appjam/smashing/global/config/TimeZoneProperties.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/config/TimeZoneProperties.kt
@@ -1,0 +1,8 @@
+package org.appjam.smashing.global.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "timezone")
+data class TimeZoneProperties(
+    val defaultTimeZone: String,
+)

--- a/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
@@ -45,6 +45,9 @@ enum class ErrorCode(
     MATCHING_RECEIVER_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH-003", "상대 유저 정보를 찾을 수 없습니다."),
     MATCHING_CANNOT_REQUEST_TO_SELF(HttpStatus.BAD_REQUEST, "MATCH-004", "본인에게 매칭을 신청할 수 없습니다."),
     MATCHING_DAILY_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "MATCH-005", "해당 유저와 오늘 매칭 가능 횟수를 초과했습니다."),
+    MATCHING_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH-006", "매칭을 찾을 수 없습니다."),
+    MATCHING_FORBIDDEN(HttpStatus.FORBIDDEN, "MATCH-007", "해당 매칭에 대한 권한이 없습니다."),
+    MATCHING_ALREADY_RESPONDED(HttpStatus.BAD_REQUEST, "MATCH-008", "이미 응답된 매칭 요청입니다."),
 
     // Domain - Notification
     NOTIFICATION_TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI-001", "알림 템플릿을 찾을 수 없습니다."),

--- a/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
@@ -37,5 +37,16 @@ enum class ErrorCode(
     MALFORMED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-014", "리프레시 토큰의 형식이 잘못되었습니다."),
     UNSUPPORTED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-015", "지원되지 않는 리프레시 토큰 형식입니다."),
     INVALID_REFRESH_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "AUTH-016", "리프레시 토큰의 타입이 올바르지 않습니다."),
-    INVALID_REFRESH_TOKEN_CONTENTS(HttpStatus.UNAUTHORIZED, "AUTH-017", "유효하지 않은 정보가 담긴 리프레시 토큰입니다.")
+    INVALID_REFRESH_TOKEN_CONTENTS(HttpStatus.UNAUTHORIZED, "AUTH-017", "유효하지 않은 정보가 담긴 리프레시 토큰입니다."),
+
+    // Domain - Matching
+    MATCHING_REQUESTER_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH-001", "요청자 유저를 찾을 수 없습니다."),
+    MATCHING_RECEIVER_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH-002", "상대 유저 스포츠 프로필을 찾을 수 없습니다."),
+    MATCHING_RECEIVER_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH-003", "상대 유저 정보를 찾을 수 없습니다."),
+    MATCHING_CANNOT_REQUEST_TO_SELF(HttpStatus.BAD_REQUEST, "MATCH-004", "본인에게 매칭을 신청할 수 없습니다."),
+    MATCHING_DAILY_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "MATCH-005", "해당 유저와 오늘 매칭 가능 횟수를 초과했습니다."),
+
+    // Domain - Notification
+    NOTIFICATION_TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI-001", "알림 템플릿을 찾을 수 없습니다."),
+
 }

--- a/src/main/kotlin/org/appjam/smashing/global/util/SecurityUtils.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/util/SecurityUtils.kt
@@ -1,0 +1,29 @@
+package org.appjam.smashing.global.util
+
+import org.appjam.smashing.global.auth.security.data.CustomUserDetails
+import org.appjam.smashing.global.exception.CustomException
+import org.appjam.smashing.global.exception.ErrorCode
+import org.springframework.security.core.context.SecurityContextHolder
+import java.time.ZoneId
+
+object SecurityUtils {
+
+    /**
+     * 현재 SecurityContext에 저장된 인증 사용자 정보 조회
+     * @return 현재 인증된 사용자(CustomUserDetails)
+     */
+    fun currentUser(): CustomUserDetails = (SecurityContextHolder.getContext().authentication?.principal as? CustomUserDetails)
+            ?: throw CustomException(ErrorCode.UNAUTHORIZED)
+
+    /**
+     * 현재 인증된 사용자의 사용자 ID 조회
+     * @return 현재 인증된 사용자의 ID
+     */
+    fun currentUserId(): String = currentUser().username
+
+    /**
+     * 현재 인증된 사용자의 타임존 정보 조회
+     * @return 현재 인증된 사용자의 ZoneId
+     */
+    fun currentZoneId(): ZoneId = ZoneId.of(currentUser().getTimeZone())
+}


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #16

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 매칭 신청 api를 작성합니다.

- 현재 저희 서비스 기능에 맞추어 해당 api에서 매칭 생성과 동시에 도메인 규칙 검증 → 알림 생성 → SSE 이벤트 전송까지 하나의 흐름으로 처리하도록 구성하고자 하였습니다.

- 매칭 신청 성공 시, 수신자에게 다음이 함께 발생합니다.
  - Notification 생성
  - SSE 이벤트 전송 (matching.received : 매칭 생성, notification.created : 알림 생성)

이때 matching.received 이벤트에는 단순 ID가 아닌, 신청자 요약 정보(닉네임, 성별, 티어, 전적, 종목 기준 후기 개수)를 함께 전달하여
추가 API 호출 없이 화면을 구성할 수 있도록 했습니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 매칭 신청 api 작성
- [x] 매칭 수락 api 작성
- [x] 매칭 거절 api 작성
- [x] 내가 보낸 매칭 요청 삭제 api 작성

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 매칭 신청
<img width="1034" height="844" alt="image" src="https://github.com/user-attachments/assets/af6a0c28-ac99-4ec1-83c3-55400627e2b1" />
<img width="1032" height="978" alt="image" src="https://github.com/user-attachments/assets/a6c2970d-a9a7-4794-bbe3-d09942deccdb" />
<img width="2390" height="348" alt="image" src="https://github.com/user-attachments/assets/6da1bae2-c54a-4b9c-aaa0-d4fa0e225438" />

- 매칭 수락
<img width="1032" height="828" alt="image" src="https://github.com/user-attachments/assets/5cf94063-c78a-45f1-827d-f2a8aa82f11c" />
<img width="1490" height="196" alt="image" src="https://github.com/user-attachments/assets/5fdcb51f-8136-48fe-8042-69e22fe5fdd2" />

- 매칭 거절
<img width="1138" height="1052" alt="image" src="https://github.com/user-attachments/assets/d03ffd16-3d8e-44fa-b044-8b2441e4cbee" />
<img width="1166" height="444" alt="image" src="https://github.com/user-attachments/assets/fab01c79-94d0-4e1f-8784-5d548b8abd77" />

- 내가 보낸 매칭 요청 삭제
<img width="503" height="412" alt="image" src="https://github.com/user-attachments/assets/da1d1807-1ace-413f-b613-7bd1adaa69d9" />

## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 현재 인증/인가 기능이 모두 완성되지 않았고, 원활한 테스트를 위해 관련 코드들을 주석 처리해놓은 상황입니다! 이후에 인증/인가 회복시 해당 부분의 주석 해제가 필요합니다.

- 현재는 한국만 고려하지만 (서비스 특성, 앱잼내 리소스 이슈) 이후에 DB와 서버의 시간 등을 UTC로 맞추고 알맞게 변환해 사용하는 로직 도입이 필요할 것같습니다. 또한 사용자 타임존을 도입해 (현재는 설정된 기본값으로 동작) 이후에 사용자의 타임존에 맞추어 서비스를 확장하기 용이할 수 있도록 하고자 하였습니다.

- 앱잼 기간동안 서버와 db의 타임존을 모두 한국으로 맞출 예정입니다. 관련해 .yml 파일의 수정이 있어 노션 한번 참고해주시면 좋을 것같습니다 ☺️