### PR TITLE
[FEAT] 경기 결과 제출 API , 경기 결과 수락 API, 경기 결과 제출안 단건 조회 API 구현

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/domain/game/controller/GameController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/controller/GameController.kt
@@ -3,6 +3,7 @@ package org.appjam.smashing.domain.game.controller
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
+import org.appjam.smashing.domain.game.dto.request.GameResultConfirmRequest
 import org.appjam.smashing.domain.game.dto.request.GameResultSubmitRequest
 import org.appjam.smashing.domain.game.service.GameService
 import org.appjam.smashing.global.common.dto.ApiResponse
@@ -37,6 +38,54 @@ class GameController(
         gameService.submitResult(
             submitterUserId = submitterUserId,
             gameId = gameId,
+            command = request.toCommand(),
+        )
+
+        return ApiResponse.success()
+    }
+
+    @Operation(
+        summary = "경기 결과 수락/확정 API",
+        description = """
+            상대가 제출한 경기 결과를 수락(확정)합니다.
+
+            [정책]
+            - game.resultStatus 는 WAITING_CONFIRMATION 이어야 합니다.
+            - submission.status 는 SUBMITTED 이어야 합니다.
+            - confirmerUserId 는 해당 submission.confirmer 와 일치해야 합니다.
+            - review 정책은 제출 API와 동일:
+              - attemptNo=1 인 제출 건을 확정할 때만 review 허용(+필수)
+              - attemptNo!=1 인 제출 건은 review 불가
+
+            [확정 시 처리]
+            - Game.resultStatus = RESULT_CONFIRMED 로 변경
+            - Game.scoreWinner/scoreLoser/confirmedAt/winner/loser/confirmedSubmissionId 세팅
+            - GameResultSubmission.status = ACCEPTED, actedAt 세팅
+            - 승/패에 따라 양쪽 UserSportProfile.wins/losses, lp 업데이트
+              - 총 경기수(기존 wins+losses 기준) 1~3판: 승 +90 / 패 -20
+              - 4~8판: 승 +45 / 패 -15
+              - 9판~: 승 +30 / 패 -20
+              - lp 는 0 미만으로 내려가지 않음
+            - lp 변경 후 Tier 테이블(minLp/maxLp) 기준으로 tier 갱신
+
+            [SSE/알림]
+            - game.updated SSE: 상대에게 발송
+            - review 포함 시:
+              - 리뷰 저장(확정자 -> 제출자)
+              - REVIEW_RECEIVED 알림 + review.received.notification.created SSE (제출자에게)
+        """
+    )
+    @PostMapping("/{gameId}/submissions/{submissionId}/confirm")
+    fun confirmGameResult(
+        @RequestHeader("userId") confirmerUserId: String, // TODO: 인증/인가 적용시 변경
+        @PathVariable gameId: String,
+        @PathVariable submissionId: String,
+        @Valid @RequestBody request: GameResultConfirmRequest,
+    ): ResponseEntity<ApiResponse<Unit>> {
+        gameService.confirmResult(
+            confirmerUserId = confirmerUserId,
+            gameId = gameId,
+            submissionId = submissionId,
             command = request.toCommand(),
         )
 

--- a/src/main/kotlin/org/appjam/smashing/domain/game/controller/GameController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/controller/GameController.kt
@@ -1,0 +1,45 @@
+package org.appjam.smashing.domain.game.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.appjam.smashing.domain.game.dto.request.GameResultSubmitRequest
+import org.appjam.smashing.domain.game.service.GameService
+import org.appjam.smashing.global.common.dto.ApiResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@Tag(name = "Game")
+@RestController
+@RequestMapping("/api/v1/games")
+class GameController(
+    private val gameService: GameService,
+) {
+
+    @Operation(
+        summary = "경기 결과 제출 API",
+        description = """
+            경기 결과를 제출합니다.
+            - 경기 생성 후 1시간 동안 제출 불가
+            - 동일 유저와 전체 2~3번째 경기인데 첫 경기로부터 30분 이내에 잡힌 경기면, 해당 경기는 생성 후 10분 동안 제출 불가
+            - review는 최초 제출(attemptNo=1)에서만 허용 (attemptNo=1이면 review 필수)
+            - 제출 성공 시 상대에게 결과 확인 알림 + 알림 SSE 전송
+            - review 포함이면 +(후기 알림 + 알림 SSE 전송)
+            - 게임 상태 WAITING_CONFIRMATION 전환 이후 SSE는 상대에게 전송
+        """
+    )
+    @PostMapping("/{gameId}/submissions")
+    fun submitGameResult(
+        @RequestHeader("userId") submitterUserId: String, // TODO: 인증/인가 적용시 변경
+        @PathVariable gameId: String,
+        @Valid @RequestBody request: GameResultSubmitRequest,
+    ): ResponseEntity<ApiResponse<Unit>> {
+        gameService.submitResult(
+            submitterUserId = submitterUserId,
+            gameId = gameId,
+            command = request.toCommand(),
+        )
+
+        return ApiResponse.success()
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/game/controller/GameController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/controller/GameController.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.appjam.smashing.domain.game.dto.request.GameResultConfirmRequest
 import org.appjam.smashing.domain.game.dto.request.GameResultSubmitRequest
+import org.appjam.smashing.domain.game.dto.response.GameResultSubmissionDetailResponse
 import org.appjam.smashing.domain.game.service.GameService
 import org.appjam.smashing.global.common.dto.ApiResponse
 import org.springframework.http.ResponseEntity
@@ -90,5 +91,26 @@ class GameController(
         )
 
         return ApiResponse.success()
+    }
+
+    @Operation(
+        summary = "경기 결과 제출안 단건 조회 API",
+        description = """
+            경기 결과 제출안(submission) 단건을 조회합니다.
+            - 제출 회차(attemptNo) / 제출자(submitter) / 제출안 기준 승자/패자 + 점수 반환
+        """
+    )
+    @GetMapping("/{gameId}/submissions/{submissionId}")
+    fun getSubmissionDetail(
+        @RequestHeader("userId") confirmerUserId: String, // TODO: 인증/인가 적용시 변경
+        @PathVariable gameId: String,
+        @PathVariable submissionId: String,
+    ): ResponseEntity<ApiResponse<GameResultSubmissionDetailResponse>> {
+        val response = gameService.getSubmissionDetail(
+            gameId = gameId,
+            submissionId = submissionId,
+        )
+
+        return ApiResponse.success(response)
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/game/controller/GameController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/controller/GameController.kt
@@ -102,7 +102,7 @@ class GameController(
     )
     @GetMapping("/{gameId}/submissions/{submissionId}")
     fun getSubmissionDetail(
-        @RequestHeader("userId") confirmerUserId: String, // TODO: 인증/인가 적용시 변경
+        @RequestHeader("userId") userId: String, // TODO: 인증/인가 적용시 변경
         @PathVariable gameId: String,
         @PathVariable submissionId: String,
     ): ResponseEntity<ApiResponse<GameResultSubmissionDetailResponse>> {

--- a/src/main/kotlin/org/appjam/smashing/domain/game/dto/command/GameResultConfirmCommand.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/dto/command/GameResultConfirmCommand.kt
@@ -1,0 +1,14 @@
+package org.appjam.smashing.domain.game.dto.command
+
+import org.appjam.smashing.domain.review.enums.ReviewRating
+import org.appjam.smashing.domain.review.enums.ReviewTag
+
+data class GameResultConfirmCommand(
+    val review: ReviewCommand?,
+) {
+    data class ReviewCommand(
+        val rating: ReviewRating,
+        val content: String?,
+        val tags: Set<ReviewTag>?,
+    )
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/game/dto/command/GameResultSubmitCommand.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/dto/command/GameResultSubmitCommand.kt
@@ -1,0 +1,18 @@
+package org.appjam.smashing.domain.game.dto.command
+
+import org.appjam.smashing.domain.review.enums.ReviewRating
+import org.appjam.smashing.domain.review.enums.ReviewTag
+
+data class GameResultSubmitCommand(
+    val winnerUserId: String,
+    val loserUserId: String,
+    val scoreWinner: Int,
+    val scoreLoser: Int,
+    val review: ReviewCommand?,
+) {
+    data class ReviewCommand(
+        val rating: ReviewRating,
+        val content: String?,
+        val tags: Set<ReviewTag>?,
+    )
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/game/dto/request/GameResultConfirmRequest.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/dto/request/GameResultConfirmRequest.kt
@@ -1,39 +1,19 @@
 package org.appjam.smashing.domain.game.dto.request
 
 import jakarta.validation.Valid
-import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
-import org.appjam.smashing.domain.game.dto.command.GameResultSubmitCommand
+import org.appjam.smashing.domain.game.dto.command.GameResultConfirmCommand
 import org.appjam.smashing.domain.review.enums.ReviewRating
 import org.appjam.smashing.domain.review.enums.ReviewTag
 import org.appjam.smashing.global.common.validator.annotation.ValidEnum
 import org.appjam.smashing.global.extensions.ofIgnoreCase
 import org.appjam.smashing.global.extensions.ofIgnoreCaseOrNull
 
-data class GameResultSubmitRequest(
-    @field:NotBlank(message = "winnerUserId는 필수입니다.")
-    val winnerUserId: String?,
-
-    @field:NotBlank(message = "loserUserId는 필수입니다.")
-    val loserUserId: String?,
-
-    @field:NotNull(message = "scoreWinner는 필수입니다.")
-    @field:Min(value = 0, message = "scoreWinner는 0 이상이어야 합니다.")
-    val scoreWinner: Int?,
-
-    @field:NotNull(message = "scoreLoser는 필수입니다.")
-    @field:Min(value = 0, message = "scoreLoser는 0 이상이어야 합니다.")
-    val scoreLoser: Int?,
-
+data class GameResultConfirmRequest(
     @field:Valid
     val review: ReviewRequest? = null,
 ) {
-    fun toCommand() = GameResultSubmitCommand(
-        winnerUserId = winnerUserId!!,
-        loserUserId = loserUserId!!,
-        scoreWinner = scoreWinner!!,
-        scoreLoser = scoreLoser!!,
+    fun toCommand() = GameResultConfirmCommand(
         review = review?.toCommand(),
     )
 
@@ -46,7 +26,7 @@ data class GameResultSubmitRequest(
 
         val tags: Set<@ValidEnum(message = "잘못된 tag 값입니다.", enumClass = ReviewTag::class) String>?,
     ) {
-        fun toCommand() = GameResultSubmitCommand.ReviewCommand(
+        fun toCommand() = GameResultConfirmCommand.ReviewCommand(
             rating = ofIgnoreCase<ReviewRating>(rating!!),
             content = content,
             tags = tags?.mapNotNull { ofIgnoreCaseOrNull<ReviewTag>(it) }?.toSet(),

--- a/src/main/kotlin/org/appjam/smashing/domain/game/dto/request/GameResultSubmitRequest.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/dto/request/GameResultSubmitRequest.kt
@@ -1,0 +1,55 @@
+package org.appjam.smashing.domain.game.dto.request
+
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import org.appjam.smashing.domain.game.dto.command.GameResultSubmitCommand
+import org.appjam.smashing.domain.review.enums.ReviewRating
+import org.appjam.smashing.domain.review.enums.ReviewTag
+import org.appjam.smashing.global.common.validator.annotation.ValidEnum
+import org.appjam.smashing.global.extensions.ofIgnoreCase
+import org.appjam.smashing.global.extensions.ofIgnoreCaseOrNull
+
+data class GameResultSubmitRequest(
+    @field:NotBlank(message = "winnerUserId는 필수입니다.")
+    val winnerUserId: String?,
+
+    @field:NotBlank(message = "loserUserId는 필수입니다.")
+    val loserUserId: String?,
+
+    @field:NotNull(message = "scoreWinner는 필수입니다.")
+    @field:Min(value = 0, message = "scoreWinner는 0 이상이어야 합니다.")
+    val scoreWinner: Int?,
+
+    @field:NotNull(message = "scoreLoser는 필수입니다.")
+    @field:Min(value = 0, message = "scoreLoser는 0 이상이어야 합니다.")
+    val scoreLoser: Int?,
+
+    @field:Valid
+    val review: ReviewRequest? = null,
+) {
+    fun toCommand() = GameResultSubmitCommand(
+        winnerUserId = winnerUserId!!,
+        loserUserId = loserUserId!!,
+        scoreWinner = scoreWinner!!,
+        scoreLoser = scoreLoser!!,
+        review = review?.toCommand(),
+    )
+
+    data class ReviewRequest(
+        @field:NotBlank(message = "review.rating은 필수입니다.")
+        @field:ValidEnum(message = "잘못된 rating 값입니다. (BAD/GOOD/BEST)", enumClass = ReviewRating::class)
+        val rating: String?,
+
+        val content: String?,
+
+        val tags: Set<@ValidEnum(message = "잘못된 tag 값입니다. (MANNER_GOOD/ON_TIME/SPORTSMANSHIP)", enumClass = ReviewTag::class) String>?,
+    ) {
+        fun toCommand() = GameResultSubmitCommand.ReviewCommand(
+            rating = ofIgnoreCase<ReviewRating>(rating!!),
+            content = content,
+            tags = tags?.mapNotNull { ofIgnoreCaseOrNull<ReviewTag>(it) }?.toSet(),
+        )
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/game/dto/response/GameResultSubmissionDetailResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/dto/response/GameResultSubmissionDetailResponse.kt
@@ -1,0 +1,48 @@
+package org.appjam.smashing.domain.game.dto.response
+
+import org.appjam.smashing.domain.game.entity.GameResultSubmission
+
+data class GameResultSubmissionDetailResponse(
+    val attemptNo: Int,
+    val submitter: SubmitterSummary,
+    val winner: SideSummary,
+    val loser: SideSummary,
+) {
+
+    data class SubmitterSummary(
+        val userId: String,
+        val nickname: String,
+    )
+
+    data class SideSummary(
+        val userId: String,
+        val nickname: String,
+        val score: Int,
+    )
+
+    companion object {
+        fun from(
+            submission: GameResultSubmission,
+            winnerScore: Int,
+            loserScore: Int,
+        ): GameResultSubmissionDetailResponse {
+            return GameResultSubmissionDetailResponse(
+                attemptNo = submission.attemptNo,
+                submitter = SubmitterSummary(
+                    userId = submission.submitter.id!!,
+                    nickname = submission.submitter.nickname,
+                ),
+                winner = SideSummary(
+                    userId = submission.winner.id!!,
+                    nickname = submission.winner.nickname,
+                    score = winnerScore,
+                ),
+                loser = SideSummary(
+                    userId = submission.loser.id!!,
+                    nickname = submission.loser.nickname,
+                    score = loserScore,
+                ),
+            )
+        }
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/game/entity/Game.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/entity/Game.kt
@@ -113,4 +113,21 @@ class Game(
     fun markWaitingConfirmation() {
         resultStatus = GameResultStatus.WAITING_CONFIRMATION
     }
+
+    fun confirmResult(
+        submissionId: String,
+        winner: User,
+        loser: User,
+        scoreWinner: Int,
+        scoreLoser: Int,
+        confirmedAt: LocalDateTime,
+    ) {
+        resultStatus = GameResultStatus.RESULT_CONFIRMED
+        confirmedSubmissionId = submissionId
+        this.winner = winner
+        this.loser = loser
+        this.scoreWinner = scoreWinner
+        this.scoreLoser = scoreLoser
+        this.confirmedAt = confirmedAt
+    }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/game/entity/Game.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/entity/Game.kt
@@ -16,7 +16,7 @@ import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import org.appjam.smashing.domain.common.entity.BaseEntity
 import org.appjam.smashing.domain.matching.entity.Matching
-import org.appjam.smashing.domain.matching.enums.GameResultStatus
+import org.appjam.smashing.domain.game.enums.GameResultStatus
 import org.appjam.smashing.domain.sport.entity.Sport
 import org.appjam.smashing.domain.user.entity.User
 import org.hibernate.annotations.Comment
@@ -47,19 +47,19 @@ class Game(
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, columnDefinition = "VARCHAR(30)")
     @Comment("경기 결과 처리 상태")
-    val resultStatus: GameResultStatus,
+    var resultStatus: GameResultStatus,
 
     @Column
     @Comment("승자 점수(확정)")
-    val scoreWinner: Int? = null,
+    var scoreWinner: Int? = null,
 
     @Column
     @Comment("패자 점수(확정)")
-    val scoreLoser: Int? = null,
+    var scoreLoser: Int? = null,
 
     @Column
     @Comment("결과 확정 시각")
-    val confirmedAt: LocalDateTime? = null,
+    var confirmedAt: LocalDateTime? = null,
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(
@@ -72,7 +72,7 @@ class Game(
 
     @Column(name = "confirmed_submission_id", length = 13)
     @Comment("최종 확정된 결과 제출 IDX")
-    val confirmedSubmissionId: String? = null,
+    var confirmedSubmissionId: String? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(
@@ -89,7 +89,7 @@ class Game(
         foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT)
     )
     @Comment("승자 유저 IDX(확정 시)")
-    val winner: User? = null,
+    var winner: User? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(
@@ -97,16 +97,20 @@ class Game(
         foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT)
     )
     @Comment("패자 유저 IDX(확정 시)")
-    val loser: User? = null,
+    var loser: User? = null,
 ) : BaseEntity() {
 
     companion object {
         fun createFromMatching(
             matching: Matching
         ) = Game(
-                resultStatus = GameResultStatus.PENDING_RESULT,
-                matching = matching,
-                sport = matching.sport,
-            )
+            resultStatus = GameResultStatus.PENDING_RESULT,
+            matching = matching,
+            sport = matching.sport,
+        )
+    }
+
+    fun markWaitingConfirmation() {
+        resultStatus = GameResultStatus.WAITING_CONFIRMATION
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/game/entity/GameResultSubmission.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/entity/GameResultSubmission.kt
@@ -124,4 +124,11 @@ class GameResultSubmission(
             loser = loser,
         )
     }
+
+    fun accept(
+        actedAt: LocalDateTime
+    ) {
+        status = SubmissionStatus.ACCEPTED
+        this.actedAt = actedAt
+    }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/game/entity/GameResultSubmission.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/entity/GameResultSubmission.kt
@@ -1,21 +1,10 @@
 package org.appjam.smashing.domain.game.entity
 
 import io.hypersistence.utils.hibernate.id.Tsid
-import jakarta.persistence.Column
-import jakarta.persistence.ConstraintMode
-import jakarta.persistence.Entity
-import jakarta.persistence.EnumType
-import jakarta.persistence.Enumerated
-import jakarta.persistence.FetchType
-import jakarta.persistence.ForeignKey
-import jakarta.persistence.Id
-import jakarta.persistence.Index
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
-import jakarta.persistence.Table
+import jakarta.persistence.*
 import org.appjam.smashing.domain.common.entity.BaseEntity
-import org.appjam.smashing.domain.matching.enums.RejectReason
-import org.appjam.smashing.domain.matching.enums.SubmissionStatus
+import org.appjam.smashing.domain.game.enums.RejectReason
+import org.appjam.smashing.domain.game.enums.SubmissionStatus
 import org.appjam.smashing.domain.user.entity.User
 import org.hibernate.annotations.Comment
 import org.hibernate.annotations.SQLDelete
@@ -52,7 +41,7 @@ class GameResultSubmission(
 
     @Column
     @Comment("상대가 맞음/틀림 누른 시각")
-    val actedAt: LocalDateTime? = null,
+    var actedAt: LocalDateTime? = null,
 
     @Column(nullable = false)
     @Comment("제출 회차")
@@ -61,7 +50,7 @@ class GameResultSubmission(
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, columnDefinition = "VARCHAR(20)")
     @Comment("제출 상태")
-    val status: SubmissionStatus,
+    var status: SubmissionStatus = SubmissionStatus.SUBMITTED,
 
     @Enumerated(EnumType.STRING)
     @Column(name = "reject_reason", columnDefinition = "VARCHAR(30)")
@@ -112,4 +101,27 @@ class GameResultSubmission(
     )
     @Comment("패자 유저 IDX(제출안 기준)")
     val loser: User,
-) : BaseEntity()
+) : BaseEntity() {
+
+    companion object {
+        fun create(
+            game: Game,
+            submitter: User,
+            confirmer: User,
+            winner: User,
+            loser: User,
+            attemptNo: Int,
+            scoreSubmitter: Int,
+            scoreConfirmer: Int,
+        ) = GameResultSubmission(
+            scoreSubmitter = scoreSubmitter,
+            scoreConfirmer = scoreConfirmer,
+            attemptNo = attemptNo,
+            game = game,
+            submitter = submitter,
+            confirmer = confirmer,
+            winner = winner,
+            loser = loser,
+        )
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/game/enums/GameResultStatus.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/enums/GameResultStatus.kt
@@ -1,0 +1,9 @@
+package org.appjam.smashing.domain.game.enums
+
+enum class GameResultStatus {
+    PENDING_RESULT,           // 경기 결과 대기 중
+    WAITING_CONFIRMATION,     // 경기 결과 확인 대기 중
+    RESULT_CONFIRMED,         // 경기 결과 확인 완료
+    RESULT_REJECTED,          // 경기 결과 거부됨
+    CANCELED                  // 경기 취소됨
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/game/enums/RejectReason.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/enums/RejectReason.kt
@@ -1,0 +1,6 @@
+package org.appjam.smashing.domain.game.enums
+
+enum class RejectReason {
+    SCORE_MISMATCH,      // 점수 불일치
+    WIN_LOSE_REVERSED    // 승패 반전
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/game/enums/SubmissionStatus.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/enums/SubmissionStatus.kt
@@ -1,0 +1,7 @@
+package org.appjam.smashing.domain.game.enums
+
+enum class SubmissionStatus {
+    SUBMITTED,     // 제출됨
+    ACCEPTED,      // 수락됨
+    REJECTED       // 거부됨
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepository.kt
@@ -1,7 +1,9 @@
 package org.appjam.smashing.domain.game.repository
 
+import jakarta.persistence.LockModeType
 import org.appjam.smashing.domain.game.entity.Game
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.LocalDateTime
@@ -10,10 +12,6 @@ interface GameRepository : JpaRepository<Game, String> {
     fun existsByMatchingId(
         matchingId: String
     ): Boolean
-
-    fun findByMatchingId(
-        matchingId: String
-    ): Game?
 
     @Query(
         value = """
@@ -34,4 +32,42 @@ interface GameRepository : JpaRepository<Game, String> {
         @Param("userA") userA: String,
         @Param("userB") userB: String,
     ): Long
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query(
+        """
+        select g
+          from Game g
+          join fetch g.matching m
+          join fetch m.requester
+          join fetch m.receiver
+          join fetch g.sport
+         where g.id = :gameId
+        """
+    )
+    fun findByIdFetchAllForUpdate(
+        gameId: String,
+    ): Game?
+
+    @Query(
+        value = """
+            select g.confirmed_at
+              from game g
+              join matching m on m.id = g.matching_id
+             where g.result_status = 'RESULT_CONFIRMED'
+               and g.confirmed_at >= :startAt
+               and (
+                    (m.requester_user_id = :userA and m.receiver_user_id = :userB)
+                 or (m.requester_user_id = :userB and m.receiver_user_id = :userA)
+               )
+             order by g.confirmed_at desc
+             limit 1
+        """,
+        nativeQuery = true
+    )
+    fun findTodayLatestConfirmedAtBetweenUsers(
+        startAt: LocalDateTime,
+        userA: String,
+        userB: String,
+    ): LocalDateTime?
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameResultSubmissionRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameResultSubmissionRepository.kt
@@ -1,7 +1,10 @@
 package org.appjam.smashing.domain.game.repository
 
+import jakarta.persistence.LockModeType
 import org.appjam.smashing.domain.game.entity.GameResultSubmission
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
 
 interface GameResultSubmissionRepository : JpaRepository<GameResultSubmission, String> {
     fun countByGame_Id(gameId: String): Long
@@ -10,4 +13,19 @@ interface GameResultSubmissionRepository : JpaRepository<GameResultSubmission, S
         gameId: String,
         submitterUserId: String,
     ): Long
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query(
+        """
+        select s
+        from GameResultSubmission s
+        where s.id = :submissionId
+          and s.game.id = :gameId
+        """
+    )
+    fun findByIdAndGameIdForUpdate(
+        submissionId: String,
+        gameId: String,
+    ): GameResultSubmission?
+
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameResultSubmissionRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameResultSubmissionRepository.kt
@@ -28,4 +28,20 @@ interface GameResultSubmissionRepository : JpaRepository<GameResultSubmission, S
         gameId: String,
     ): GameResultSubmission?
 
+    @Query(
+        """
+        select s
+          from GameResultSubmission s
+          join fetch s.submitter
+          join fetch s.confirmer
+          join fetch s.winner
+          join fetch s.loser
+         where s.id = :submissionId
+           and s.game.id = :gameId
+        """
+    )
+    fun findDetailByIdAndGameId(
+        submissionId: String,
+        gameId: String,
+    ): GameResultSubmission?
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameResultSubmissionRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameResultSubmissionRepository.kt
@@ -1,0 +1,13 @@
+package org.appjam.smashing.domain.game.repository
+
+import org.appjam.smashing.domain.game.entity.GameResultSubmission
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface GameResultSubmissionRepository : JpaRepository<GameResultSubmission, String> {
+    fun countByGame_Id(gameId: String): Long
+
+    fun countByGame_IdAndSubmitter_Id(
+        gameId: String,
+        submitterUserId: String,
+    ): Long
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
@@ -537,8 +537,8 @@ class GameService(
         sportId: Long,
     ) {
         // 승/패 수 갱신
-        winnerProfile.wins += 1
-        loserProfile.losses += 1
+        winnerProfile.recordWin()
+        loserProfile.recordLoss()
 
         // 각자 이번 경기가 몇 번째 경기인지 계산 (업데이트 후 wins+losses 기준)
         val winnerGameNo = (winnerProfile.wins + winnerProfile.losses)

--- a/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
@@ -1,0 +1,348 @@
+package org.appjam.smashing.domain.game.service
+
+import org.appjam.smashing.domain.game.dto.command.GameResultSubmitCommand
+import org.appjam.smashing.domain.game.entity.Game
+import org.appjam.smashing.domain.game.entity.GameResultSubmission
+import org.appjam.smashing.domain.game.enums.GameResultStatus
+import org.appjam.smashing.domain.game.repository.GameRepository
+import org.appjam.smashing.domain.game.repository.GameResultSubmissionRepository
+import org.appjam.smashing.domain.notification.enums.NotificationType
+import org.appjam.smashing.domain.notification.service.NotificationService
+import org.appjam.smashing.domain.outbox.components.OutboxEventPublisher
+import org.appjam.smashing.domain.outbox.dto.GameResultSubmittedNotificationCreatedPayload
+import org.appjam.smashing.domain.outbox.dto.GameUpdatedPayload
+import org.appjam.smashing.domain.outbox.dto.ReviewReceivedNotificationCreatedPayload
+import org.appjam.smashing.domain.outbox.enums.SseEventType
+import org.appjam.smashing.domain.review.service.GameReviewService
+import org.appjam.smashing.domain.user.entity.User
+import org.appjam.smashing.domain.user.repository.UserSportProfileRepository
+import org.appjam.smashing.global.exception.CustomException
+import org.appjam.smashing.global.exception.ErrorCode
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+
+@Service
+class GameService(
+    private val gameRepository: GameRepository,
+    private val submissionRepository: GameResultSubmissionRepository,
+    private val notificationService: NotificationService,
+    private val outboxEventPublisher: OutboxEventPublisher,
+    private val gameReviewService: GameReviewService,
+    private val userSportProfileRepository: UserSportProfileRepository,
+) {
+
+    @Transactional
+    fun submitResult(
+        submitterUserId: String,
+        gameId: String,
+        command: GameResultSubmitCommand,
+    ) {
+        // 게임 조회(잠금)
+        val game = gameRepository.findByIdFetchAllForUpdate(gameId)
+            ?: throw CustomException(ErrorCode.GAME_NOT_FOUND)
+
+        // 게임 상태 검증
+        if (game.resultStatus != GameResultStatus.PENDING_RESULT && game.resultStatus != GameResultStatus.RESULT_REJECTED) {
+            throw CustomException(ErrorCode.GAME_RESULT_ALREADY_SUBMITTED)
+        }
+
+        // 제출자/상대 결정
+        val requester = game.matching.requester
+        val receiver = game.matching.receiver
+        val (submitter, confirmer) = determineSubmitterAndConfirmer(submitterUserId, requester, receiver)
+
+        val submitterProfile = userSportProfileRepository.findByUserIdAndSportIdFetch(
+            userId = submitter.id!!,
+            sportId = game.sport.id!!,
+        ) ?: throw CustomException(ErrorCode.MATCHING_REQUESTER_NOT_FOUND)
+
+        val confirmerProfile = userSportProfileRepository.findByUserIdAndSportIdFetch(
+            userId = confirmer.id!!,
+            sportId = game.sport.id!!,
+        ) ?: throw CustomException(ErrorCode.MATCHING_RECEIVER_PROFILE_NOT_FOUND)
+
+        // 유저당 제출 2회 제한
+        if (submissionRepository.countByGame_IdAndSubmitter_Id(gameId, submitterUserId) >= 2L) {
+            throw CustomException(ErrorCode.GAME_RESULT_SUBMISSION_LIMIT_EXCEEDED)
+        }
+
+        // 게임 결과 제출 시간 제약
+        validateSubmitWindow(game)
+
+        // attemptNo = 해당 게임 제출 순번 계산
+        val attemptNo = (submissionRepository.countByGame_Id(gameId) + 1).toInt()
+
+        // 리뷰 검증 (첫 제출 시 필수, 재제출 시 불가)
+        validateReviewRule(attemptNo, command.review)
+
+        // score 검증, winner/loser 검증
+        validateWinnerLoserAndScores(
+            winnerUserId = command.winnerUserId,
+            loserUserId = command.loserUserId,
+            scoreWinner = command.scoreWinner,
+            scoreLoser = command.scoreLoser,
+            requesterUserId = requester.id!!,
+            receiverUserId = receiver.id!!,
+        )
+
+        // winner/loser 엔티티 매핑
+        val (winner, loser) = determineWinnerAndLoser(game, command.winnerUserId, command.loserUserId)
+
+        // 게임 상태 변경
+        game.markWaitingConfirmation()
+
+        // 경기 결과 제출안 저장
+        val submission = submissionRepository.save(
+            GameResultSubmission.create(
+                game = game,
+                submitter = submitter,
+                confirmer = confirmer,
+                winner = winner,
+                loser = loser,
+                attemptNo = attemptNo,
+                scoreSubmitter = if (submitter.id == command.winnerUserId) command.scoreWinner else command.scoreLoser,
+                scoreConfirmer = if (confirmer.id == command.winnerUserId) command.scoreWinner else command.scoreLoser,
+            )
+        )
+
+        // 게임 상태 변경 SSE 발행
+        publishGameUpdated(
+            receiverUserId = confirmer.id!!,
+            gameId = gameId,
+            resultStatus = game.resultStatus
+        )
+
+        // 결과 제출 알림 + SSE 발행
+        notifyGameResultSubmitted(
+            receiver = confirmer,
+            game = game,
+            submission = submission,
+            submitter = submitter,
+            receiverProfileId = confirmerProfile.id!!,
+            submitterTierId = submitterProfile.tier.id!!,
+        )
+
+        // 후기 저장 + 후기 제출 알림 + SSE 발행
+        if (attemptNo == 1) {
+            notifyReviewReceived(
+                game = game,
+                reviewer = submitter,
+                reviewee = confirmer,
+                review = command.review!!,
+                receiverProfileId = confirmerProfile.id!!,
+                reviewerTierId = submitterProfile.tier.id!!,
+            )
+        }
+    }
+
+    private fun determineSubmitterAndConfirmer(
+        submitterUserId: String,
+        requester: User,
+        receiver: User,
+    ): Pair<User, User> {
+        if (submitterUserId != requester.id!! && submitterUserId != receiver.id!!) {
+            throw CustomException(ErrorCode.GAME_FORBIDDEN)
+        }
+        return if (submitterUserId == requester.id!!) requester to receiver else receiver to requester
+    }
+
+    private fun determineWinnerAndLoser(
+        game: Game,
+        winnerUserId: String,
+        loserUserId: String,
+    ): Pair<User, User> {
+        val requester = game.matching.requester
+        val receiver = game.matching.receiver
+
+        val winner = if (winnerUserId == requester.id!!) requester else receiver
+        val loser = if (loserUserId == requester.id!!) requester else receiver
+
+        return winner to loser
+    }
+
+    private fun validateReviewRule(
+        attemptNo: Int,
+        review: GameResultSubmitCommand.ReviewCommand?,
+    ) {
+        if (attemptNo == 1 && review == null) {
+            throw CustomException(ErrorCode.GAME_REVIEW_REQUIRED_ON_FIRST_SUBMISSION)
+        }
+        if (attemptNo != 1 && review != null) {
+            throw CustomException(ErrorCode.GAME_REVIEW_ONLY_FIRST_SUBMISSION_ALLOWED)
+        }
+    }
+
+    private fun validateWinnerLoserAndScores(
+        winnerUserId: String,
+        loserUserId: String,
+        scoreWinner: Int,
+        scoreLoser: Int,
+        requesterUserId: String,
+        receiverUserId: String,
+    ) {
+        if (winnerUserId == loserUserId) throw CustomException(ErrorCode.GAME_RESULT_SAME_PLAYER)
+        if (scoreWinner <= scoreLoser) throw CustomException(ErrorCode.GAME_RESULT_INVALID_SCORE)
+
+        if ((winnerUserId != requesterUserId && winnerUserId != receiverUserId) || (loserUserId != requesterUserId && loserUserId != receiverUserId)) {
+            throw CustomException(ErrorCode.GAME_RESULT_INVALID_PLAYERS)
+        }
+    }
+
+    /**
+     * 오늘 기준(00:00~)
+     * - 오늘 확정 0건이면(= 오늘 첫 확정 후보): 생성 후 1시간 제출 불가
+     * - 오늘 확정 1~2건이면(= 오늘 2~3번째 확정 후보):
+     *   직전 확정이 30분 이내에 있었던 연속 확정 상황일 때만
+     *   생성 후 10분 제출 불가
+     */
+    private fun validateSubmitWindow(game: Game) {
+        val now = LocalDateTime.now(DEFAULT_ZONE_ID)
+        val startOfDay = now.toLocalDate().atStartOfDay()
+
+        val requesterId = game.matching.requester.id!!
+        val receiverId = game.matching.receiver.id!!
+
+        val todayConfirmedCount = gameRepository.countTodayConfirmedGamesBetweenUsers(
+            startAt = startOfDay,
+            userA = requesterId,
+            userB = receiverId,
+        )
+
+        // 오늘 첫 확정 후보 → 1시간 결과 제출 제한
+        if (todayConfirmedCount == 0L) {
+            if (ChronoUnit.MINUTES.between(game.createdAt, now) < 60) {
+                throw CustomException(ErrorCode.GAME_RESULT_SUBMIT_BLOCKED_1H)
+            }
+            return
+        }
+
+        // 오늘 2~3번째 확정 후보 → 연속 확정일 때만 10분 룰
+        if (todayConfirmedCount in 1L..2L) {
+            val prevConfirmedAt = gameRepository.findTodayLatestConfirmedAtBetweenUsers(
+                startAt = startOfDay,
+                userA = requesterId,
+                userB = receiverId,
+            ) ?: return
+
+            // 직전 확정 이후 30분 이내에 게임 → 현재 게임은 생성 후 10분 결과 제출 제한
+            if (ChronoUnit.MINUTES.between(prevConfirmedAt, now) <= 30) {
+                if (ChronoUnit.MINUTES.between(game.createdAt, now) < 10) {
+                    throw CustomException(ErrorCode.GAME_RESULT_SUBMIT_BLOCKED_10M)
+                }
+            }
+        }
+    }
+
+    private fun notifyGameResultSubmitted(
+        receiver: User,
+        game: Game,
+        submission: GameResultSubmission,
+        submitter: User,
+        receiverProfileId: String,
+        submitterTierId: Long,
+    ) {
+        val notification = notificationService.createMatchingResultSubmitted(
+            receiver = receiver,
+            gameId = game.id!!,
+            submissionId = submission.id!!,
+            submitterNickname = submitter.nickname,
+            submitterTierId = submitterTierId,
+        )
+
+        val notificationCreatedAt = notification.createdAt
+            .atZone(DEFAULT_ZONE_ID)
+            .toOffsetDateTime()
+            .toString()
+
+        outboxEventPublisher.publish(
+            userId = receiver.id!!,
+            eventType = SseEventType.GAME_RESULT_SUBMITTED_NOTIFICATION_CREATED,
+            payload = GameResultSubmittedNotificationCreatedPayload(
+                notificationId = notification.id!!,
+                notificationType = NotificationType.MATCHING_RESULT_SUBMITTED,
+                notificationCreatedAt = notificationCreatedAt,
+                sportId = game.sport.id!!,
+                receiverProfileId = receiverProfileId,
+                gameId = game.id!!,
+                submissionId = submission.id!!,
+                submitter = GameResultSubmittedNotificationCreatedPayload.SubmitterSummary(
+                    userId = submitter.id!!,
+                    nickname = submitter.nickname,
+                    tierId = submitterTierId,
+                )
+            )
+        )
+    }
+
+    private fun notifyReviewReceived(
+        game: Game,
+        reviewer: User,
+        reviewee: User,
+        review: GameResultSubmitCommand.ReviewCommand,
+        receiverProfileId: String,
+        reviewerTierId: Long,
+    ) {
+        val savedReview = gameReviewService.createReview(
+            gameId = game.id!!,
+            reviewer = reviewer,
+            reviewee = reviewee,
+            rating = review.rating,
+            content = review.content,
+            tags = review.tags,
+        )
+
+        val notification = notificationService.createReviewReceived(
+            receiver = reviewee,
+            reviewId = savedReview.id!!,
+            reviewerNickname = reviewer.nickname,
+            reviewerTierId = reviewerTierId,
+            gameId = game.id!!,
+        )
+
+        val notificationCreatedAt = notification.createdAt
+            .atZone(DEFAULT_ZONE_ID)
+            .toOffsetDateTime()
+            .toString()
+
+        outboxEventPublisher.publish(
+            userId = reviewee.id!!,
+            eventType = SseEventType.REVIEW_RECEIVED_NOTIFICATION_CREATED,
+            payload = ReviewReceivedNotificationCreatedPayload(
+                notificationId = notification.id!!,
+                notificationType = NotificationType.REVIEW_RECEIVED,
+                notificationCreatedAt = notificationCreatedAt,
+                sportId = game.sport.id!!,
+                receiverProfileId = receiverProfileId,
+                gameId = game.id!!,
+                reviewId = savedReview.id!!,
+                reviewer = ReviewReceivedNotificationCreatedPayload.ReviewerSummary(
+                    userId = reviewer.id!!,
+                    nickname = reviewer.nickname,
+                    tierId = reviewerTierId,
+                )
+            )
+        )
+    }
+
+    private fun publishGameUpdated(
+        receiverUserId: String,
+        gameId: String,
+        resultStatus: GameResultStatus,
+    ) {
+        outboxEventPublisher.publish(
+            userId = receiverUserId,
+            eventType = SseEventType.GAME_UPDATED,
+            payload = GameUpdatedPayload(
+                gameId = gameId,
+                resultStatus = resultStatus,
+            )
+        )
+    }
+
+    companion object {
+        private val DEFAULT_ZONE_ID = ZoneId.of("Asia/Seoul")
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
@@ -1,9 +1,11 @@
 package org.appjam.smashing.domain.game.service
 
+import org.appjam.smashing.domain.game.dto.command.GameResultConfirmCommand
 import org.appjam.smashing.domain.game.dto.command.GameResultSubmitCommand
 import org.appjam.smashing.domain.game.entity.Game
 import org.appjam.smashing.domain.game.entity.GameResultSubmission
 import org.appjam.smashing.domain.game.enums.GameResultStatus
+import org.appjam.smashing.domain.game.enums.SubmissionStatus
 import org.appjam.smashing.domain.game.repository.GameRepository
 import org.appjam.smashing.domain.game.repository.GameResultSubmissionRepository
 import org.appjam.smashing.domain.notification.enums.NotificationType
@@ -14,7 +16,10 @@ import org.appjam.smashing.domain.outbox.dto.GameUpdatedPayload
 import org.appjam.smashing.domain.outbox.dto.ReviewReceivedNotificationCreatedPayload
 import org.appjam.smashing.domain.outbox.enums.SseEventType
 import org.appjam.smashing.domain.review.service.GameReviewService
+import org.appjam.smashing.domain.tier.entity.Tier
+import org.appjam.smashing.domain.tier.repository.TierRepository
 import org.appjam.smashing.domain.user.entity.User
+import org.appjam.smashing.domain.user.entity.UserSportProfile
 import org.appjam.smashing.domain.user.repository.UserSportProfileRepository
 import org.appjam.smashing.global.exception.CustomException
 import org.appjam.smashing.global.exception.ErrorCode
@@ -32,6 +37,7 @@ class GameService(
     private val outboxEventPublisher: OutboxEventPublisher,
     private val gameReviewService: GameReviewService,
     private val userSportProfileRepository: UserSportProfileRepository,
+    private val tierRepository: TierRepository,
 ) {
 
     @Transactional
@@ -138,6 +144,106 @@ class GameService(
         }
     }
 
+    @Transactional
+    fun confirmResult(
+        confirmerUserId: String,
+        gameId: String,
+        submissionId: String,
+        command: GameResultConfirmCommand,
+    ) {
+        val now = LocalDateTime.now(DEFAULT_ZONE_ID)
+
+        // 게임 조회(잠금)
+        val game = gameRepository.findByIdFetchAllForUpdate(gameId)
+            ?: throw CustomException(ErrorCode.GAME_NOT_FOUND)
+
+        // 상태 검증
+        if (game.resultStatus != GameResultStatus.WAITING_CONFIRMATION) {
+            throw CustomException(ErrorCode.GAME_RESULT_NOT_WAITING_CONFIRMATION)
+        }
+
+        // 제출안 조회(잠금)
+        val submission = submissionRepository.findByIdAndGameIdForUpdate(submissionId, gameId)
+            ?: throw CustomException(ErrorCode.GAME_SUBMISSION_NOT_FOUND)
+
+        // 제출안 상태 검증
+        if (submission.status != SubmissionStatus.SUBMITTED) {
+            throw CustomException(ErrorCode.GAME_SUBMISSION_NOT_SUBMITTED)
+        }
+
+        // confirmer 검증
+        if (submission.confirmer.id != confirmerUserId) {
+            throw CustomException(ErrorCode.GAME_SUBMISSION_CONFIRMER_MISMATCH)
+        }
+
+        // review 정책 검증
+        validateConfirmReviewRule(
+            attemptNo = submission.attemptNo,
+            review = command.review,
+        )
+
+        // 확정 점수 매핑
+        val scoreWinner = if (submission.winner.id == submission.submitter.id) submission.scoreSubmitter else submission.scoreConfirmer
+        val scoreLoser = if (submission.loser.id == submission.submitter.id) submission.scoreSubmitter else submission.scoreConfirmer
+
+        // game 확정 + submission 수락
+        game.confirmResult(
+            submissionId = submission.id!!,
+            winner = submission.winner,
+            loser = submission.loser,
+            scoreWinner = scoreWinner,
+            scoreLoser = scoreLoser,
+            confirmedAt = now,
+        )
+        submission.accept(now)
+
+        // 승자/패자 프로필 조회(잠금)
+        val sportId = game.sport.id!!
+        val submitterProfile = userSportProfileRepository.findByUserIdAndSportIdForUpdate(submission.submitter.id!!, sportId)
+            ?: throw CustomException(ErrorCode.USER_SPORT_PROFILE_NOT_FOUND)
+
+        val confirmerProfile = userSportProfileRepository
+            .findByUserIdAndSportIdForUpdate(submission.confirmer.id!!, sportId)
+            ?: throw CustomException(ErrorCode.USER_SPORT_PROFILE_NOT_FOUND)
+
+        // 승자/패자 프로필 업데이트 (승리/패배 수 + LP + 티어)
+        val winnerProfile = if (submission.winner.id == submission.submitter.id) submitterProfile else confirmerProfile
+        val loserProfile = if (submission.loser.id == submission.submitter.id) submitterProfile else confirmerProfile
+
+        applyLpAndTierUpdate(winnerProfile, loserProfile, sportId)
+
+        // 게임 상태 변경 SSE 발행
+        publishGameUpdated(
+            receiverUserId = submission.submitter.id!!,
+            gameId = game.id!!,
+            resultStatus = game.resultStatus,
+        )
+
+        // 후기 저장 + 후기 제출 알림 + SSE 발행
+        if (submission.attemptNo == 1) {
+            notifyReviewReceivedOnConfirm(
+                game = game,
+                reviewer = submission.confirmer,
+                reviewee = submission.submitter,
+                review = command.review!!,
+                receiverProfileId = submitterProfile.id!!,
+                reviewerTierId = confirmerProfile.tier.id!!,
+            )
+        }
+    }
+
+    private fun validateConfirmReviewRule(
+        attemptNo: Int,
+        review: GameResultConfirmCommand.ReviewCommand?,
+    ) {
+        if (attemptNo == 1 && review == null) {
+            throw CustomException(ErrorCode.GAME_REVIEW_REQUIRED_ON_FIRST_SUBMISSION)
+        }
+        if (attemptNo != 1 && review != null) {
+            throw CustomException(ErrorCode.GAME_REVIEW_ONLY_FIRST_SUBMISSION_ALLOWED)
+        }
+    }
+
     private fun determineSubmitterAndConfirmer(
         submitterUserId: String,
         requester: User,
@@ -182,7 +288,7 @@ class GameService(
         scoreLoser: Int,
         requesterUserId: String,
         receiverUserId: String,
-    ) {
+    ) { // TODO: 승자 패자 결정 부분 기획 미확정. 동점 일시 기획 미확정. 확정 시 리팩토링 필요
         if (winnerUserId == loserUserId) throw CustomException(ErrorCode.GAME_RESULT_SAME_PLAYER)
         if (scoreWinner <= scoreLoser) throw CustomException(ErrorCode.GAME_RESULT_INVALID_SCORE)
 
@@ -327,6 +433,56 @@ class GameService(
         )
     }
 
+    private fun notifyReviewReceivedOnConfirm(
+        game: Game,
+        reviewer: User,
+        reviewee: User,
+        review: GameResultConfirmCommand.ReviewCommand,
+        receiverProfileId: String,
+        reviewerTierId: Long,
+    ) {
+        val savedReview = gameReviewService.createReview(
+            gameId = game.id!!,
+            reviewer = reviewer,
+            reviewee = reviewee,
+            rating = review.rating,
+            content = review.content,
+            tags = review.tags,
+        )
+
+        val notification = notificationService.createReviewReceived(
+            receiver = reviewee,
+            reviewId = savedReview.id!!,
+            reviewerNickname = reviewer.nickname,
+            reviewerTierId = reviewerTierId,
+            gameId = game.id!!,
+        )
+
+        val notificationCreatedAt = notification.createdAt
+            .atZone(DEFAULT_ZONE_ID)
+            .toOffsetDateTime()
+            .toString()
+
+        outboxEventPublisher.publish(
+            userId = reviewee.id!!,
+            eventType = SseEventType.REVIEW_RECEIVED_NOTIFICATION_CREATED,
+            payload = ReviewReceivedNotificationCreatedPayload(
+                notificationId = notification.id!!,
+                notificationType = NotificationType.REVIEW_RECEIVED,
+                notificationCreatedAt = notificationCreatedAt,
+                sportId = game.sport.id!!,
+                receiverProfileId = receiverProfileId,
+                gameId = game.id!!,
+                reviewId = savedReview.id!!,
+                reviewer = ReviewReceivedNotificationCreatedPayload.ReviewerSummary(
+                    userId = reviewer.id!!,
+                    nickname = reviewer.nickname,
+                    tierId = reviewerTierId,
+                )
+            )
+        )
+    }
+
     private fun publishGameUpdated(
         receiverUserId: String,
         gameId: String,
@@ -340,6 +496,60 @@ class GameService(
                 resultStatus = resultStatus,
             )
         )
+    }
+
+    private fun applyLpAndTierUpdate(
+        winnerProfile: UserSportProfile,
+        loserProfile: UserSportProfile,
+        sportId: Long,
+    ) {
+        // 승/패 수 갱신
+        winnerProfile.wins += 1
+        loserProfile.losses += 1
+
+        // 각자 이번 경기가 몇 번째 경기인지 계산 (업데이트 후 wins+losses 기준)
+        val winnerGameNo = (winnerProfile.wins + winnerProfile.losses)
+        val loserGameNo = (loserProfile.wins + loserProfile.losses)
+
+        // 구간별 lp 증감 계산
+        val winnerLpDelta = calcWinLpDelta(winnerGameNo)
+        val loserLpDelta = calcLoseLpDelta(loserGameNo)
+
+        // lp 반영 (0 미만 방지)
+        winnerProfile.lp += winnerLpDelta
+        loserProfile.lp = (loserProfile.lp - loserLpDelta).coerceAtLeast(0)
+
+        // lp 기준 tier 재계산/갱신
+        winnerProfile.changeTier(resolveTierOrThrow(sportId, winnerProfile.lp))
+        loserProfile.changeTier(resolveTierOrThrow(sportId, loserProfile.lp))
+    }
+
+    private fun calcWinLpDelta(
+        gameNo: Int
+    ): Int {
+        return when (gameNo) {
+            in 1..3 -> 90
+            in 4..8 -> 45
+            else -> 30
+        }
+    }
+
+    private fun calcLoseLpDelta(
+        gameNo: Int
+    ): Int {
+        return when (gameNo) {
+            in 1..3 -> 20
+            in 4..8 -> 15
+            else -> 20
+        }
+    }
+
+    private fun resolveTierOrThrow(
+        sportId: Long,
+        lp: Int
+    ): Tier {
+        return tierRepository.findBySportIdAndLpInRange(sportId, lp)
+            ?: throw CustomException(ErrorCode.TIER_NOT_FOUND) // TODO: 추후 챌린저 관련 maxlp 처리 필요
     }
 
     companion object {

--- a/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
@@ -2,6 +2,7 @@ package org.appjam.smashing.domain.game.service
 
 import org.appjam.smashing.domain.game.dto.command.GameResultConfirmCommand
 import org.appjam.smashing.domain.game.dto.command.GameResultSubmitCommand
+import org.appjam.smashing.domain.game.dto.response.GameResultSubmissionDetailResponse
 import org.appjam.smashing.domain.game.entity.Game
 import org.appjam.smashing.domain.game.entity.GameResultSubmission
 import org.appjam.smashing.domain.game.enums.GameResultStatus
@@ -232,6 +233,38 @@ class GameService(
         }
     }
 
+    @Transactional(readOnly = true)
+    fun getSubmissionDetail(
+        gameId: String,
+        submissionId: String,
+    ): GameResultSubmissionDetailResponse {
+        val submission = submissionRepository.findDetailByIdAndGameId(
+            submissionId = submissionId,
+            gameId = gameId,
+        ) ?: throw CustomException(ErrorCode.GAME_SUBMISSION_NOT_FOUND)
+
+        // 점수 매핑
+        val winnerScore = scoreOf(submission, submission.winner.id!!)
+        val loserScore = scoreOf(submission, submission.loser.id!!)
+
+        return GameResultSubmissionDetailResponse.from(
+            submission = submission,
+            winnerScore = winnerScore,
+            loserScore = loserScore,
+        )
+    }
+
+    private fun scoreOf(
+        submission: GameResultSubmission,
+        userId: String,
+    ): Int {
+        return when (userId) {
+            submission.submitter.id!! -> submission.scoreSubmitter
+            submission.confirmer.id!! -> submission.scoreConfirmer
+            else -> throw CustomException(ErrorCode.GAME_RESULT_INVALID_PLAYERS)
+        }
+    }
+
     private fun validateConfirmReviewRule(
         attemptNo: Int,
         review: GameResultConfirmCommand.ReviewCommand?,
@@ -288,7 +321,7 @@ class GameService(
         scoreLoser: Int,
         requesterUserId: String,
         receiverUserId: String,
-    ) { // TODO: 승자 패자 결정 부분 기획 미확정. 동점 일시 기획 미확정. 확정 시 리팩토링 필요
+    ) {
         if (winnerUserId == loserUserId) throw CustomException(ErrorCode.GAME_RESULT_SAME_PLAYER)
         if (scoreWinner <= scoreLoser) throw CustomException(ErrorCode.GAME_RESULT_INVALID_SCORE)
 

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/enums/GameResultStatus.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/enums/GameResultStatus.kt
@@ -1,5 +1,0 @@
-package org.appjam.smashing.domain.matching.enums
-
-enum class GameResultStatus {
-    PENDING_RESULT, RESULT_CONFIRMED, CANCELED
-}

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/enums/RejectReason.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/enums/RejectReason.kt
@@ -1,6 +1,0 @@
-package org.appjam.smashing.domain.matching.enums
-
-enum class RejectReason {
-    SCORE_MISMATCH,
-    WIN_LOSE_REVERSED
-}

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/enums/SubmissionStatus.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/enums/SubmissionStatus.kt
@@ -1,5 +1,0 @@
-package org.appjam.smashing.domain.matching.enums
-
-enum class SubmissionStatus {
-    SUBMITTED, ACCEPTED, REJECTED
-}

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/entity/Notification.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/entity/Notification.kt
@@ -81,5 +81,35 @@ class Notification(
                 user = receiver,
                 notificationTemplate = template,
             )
+
+        fun createMatchingResultSubmitted(
+            receiver: User,
+            template: NotificationTemplate,
+            gameId: String,
+            submissionId: String,
+            submitterNickname: String,
+            submitterTierId: Long,
+        ) = Notification(
+            params = """{"submitterNickname":"$submitterNickname","submitterTierId":$submitterTierId,"gameId":"$gameId","submissionId":"$submissionId"}""",
+            isRead = false,
+            linkUrl = "/api/v1/users/me/matchings/accepted/pending-result",
+            user = receiver,
+            notificationTemplate = template,
+        )
+
+        fun createReviewReceived(
+            receiver: User,
+            template: NotificationTemplate,
+            reviewId: String,
+            reviewerNickname: String,
+            reviewerTierId: Long,
+            gameId: String,
+        ) = Notification(
+            params = """{"reviewerNickname":"$reviewerNickname","reviewerTierId":$reviewerTierId,"reviewId":"$reviewId","gameId":"$gameId"}""",
+            isRead = false,
+            linkUrl = "/api/v1/reviews/$reviewId",
+            user = receiver,
+            notificationTemplate = template,
+        )
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/service/NotificationService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/service/NotificationService.kt
@@ -47,4 +47,48 @@ class NotificationService(
             )
         )
     }
+
+    fun createMatchingResultSubmitted(
+        receiver: User,
+        gameId: String,
+        submissionId: String,
+        submitterNickname: String,
+        submitterTierId: Long,
+    ): Notification {
+        val template = notificationTemplateRepository.findByType(NotificationType.MATCHING_RESULT_SUBMITTED)
+            ?: throw CustomException(ErrorCode.NOTIFICATION_TEMPLATE_NOT_FOUND)
+
+        return notificationRepository.save(
+            Notification.createMatchingResultSubmitted(
+                receiver = receiver,
+                template = template,
+                gameId = gameId,
+                submissionId = submissionId,
+                submitterNickname = submitterNickname,
+                submitterTierId = submitterTierId,
+            )
+        )
+    }
+
+    fun createReviewReceived(
+        receiver: User,
+        reviewId: String,
+        reviewerNickname: String,
+        reviewerTierId: Long,
+        gameId: String,
+    ): Notification {
+        val template = notificationTemplateRepository.findByType(NotificationType.REVIEW_RECEIVED)
+            ?: throw CustomException(ErrorCode.NOTIFICATION_TEMPLATE_NOT_FOUND)
+
+        return notificationRepository.save(
+            Notification.createReviewReceived(
+                receiver = receiver,
+                template = template,
+                reviewId = reviewId,
+                reviewerNickname = reviewerNickname,
+                reviewerTierId = reviewerTierId,
+                gameId = gameId,
+            )
+        )
+    }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/outbox/dto/SsePayload.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/outbox/dto/SsePayload.kt
@@ -1,5 +1,6 @@
 package org.appjam.smashing.domain.outbox.dto
 
+import org.appjam.smashing.domain.game.enums.GameResultStatus
 import org.appjam.smashing.domain.notification.enums.NotificationType
 import org.appjam.smashing.domain.outbox.enums.MatchingUpdateStatus
 import org.appjam.smashing.domain.outbox.enums.SseEventType
@@ -8,6 +9,18 @@ import org.appjam.smashing.domain.user.enums.Gender
 sealed interface SsePayload {
     val type: String
 }
+
+/**
+ * 매칭 상태 변경
+ * - 보낸 요청 / 매칭확정 / 요청삭제
+ * - 상대가 내 요청을 ACCEPT/REJECT 하는 순간
+ * - 상대가 보낸 요청을 CANCELLED 하는 순간
+ */
+data class MatchingUpdatedPayload(
+    override val type: String = SseEventType.MATCHING_UPDATED.eventName,
+    val matchingId: String,
+    val status: MatchingUpdateStatus,
+) : SsePayload
 
 /**
  * 매칭관리 - 받은 요청
@@ -31,28 +44,6 @@ data class MatchingReceivedPayload(
         val reviewCount: Long,
     )
 }
-
-/**
- * 매칭관리 - 보낸 요청 / 매칭확정 / 요청삭제
- * - 상대가 내 요청을 ACCEPT/REJECT 하는 순간
- * - 상대가 보낸 요청을 CANCELLED 하는 순간
- */
-data class MatchingUpdatedPayload(
-    override val type: String = SseEventType.MATCHING_UPDATED.eventName,
-    val matchingId: String,
-    val status: MatchingUpdateStatus,
-) : SsePayload
-
-/**
- * 알림 생성
- * - 알림이 생성된 순간만 SSE로 푸시
- */
-data class NotificationCreatedPayload(
-    override val type: String = SseEventType.NOTIFICATION_CREATED.eventName,
-    val notificationId: String,
-    val notificationType: NotificationType,
-    val targetId: String? = null,           // matchingId/gameId/reviewId 등
-) : SsePayload
 
 /**
  * 매칭 신청 알림 생성
@@ -92,6 +83,62 @@ data class MatchingAcceptNotificationCreatedPayload(
 ) : SsePayload {
 
     data class AcceptorSummary(
+        val userId: String,
+        val nickname: String,
+        val tierId: Long,
+    )
+}
+
+/**
+ * 게임 상태 변경
+ * - 게임 결과 상태(resultStatus)가 변경된 순간
+ */
+data class GameUpdatedPayload(
+    override val type: String = SseEventType.GAME_UPDATED.eventName,
+    val gameId: String,
+    val resultStatus: GameResultStatus,
+) : SsePayload
+
+/**
+ * 게임 결과 제출 알림 생성
+ * - 상대가 경기 결과를 제출한 순간 알림 생성
+ */
+data class GameResultSubmittedNotificationCreatedPayload(
+    override val type: String = SseEventType.GAME_RESULT_SUBMITTED_NOTIFICATION_CREATED.eventName,
+    val notificationId: String,
+    val notificationType: NotificationType,
+    val notificationCreatedAt: String,
+    val sportId: Long,
+    val receiverProfileId: String,
+    val gameId: String,
+    val submissionId: String,
+    val submitter: SubmitterSummary,
+) : SsePayload {
+
+    data class SubmitterSummary(
+        val userId: String,
+        val nickname: String,
+        val tierId: Long,
+    )
+}
+
+/**
+ * 리뷰(후기) 제출 알림 생성
+ * - 상대가 나에게 후기를 남긴 순간 알림 생성
+ */
+data class ReviewReceivedNotificationCreatedPayload(
+    override val type: String = SseEventType.REVIEW_RECEIVED_NOTIFICATION_CREATED.eventName,
+    val notificationId: String,
+    val notificationType: NotificationType,
+    val notificationCreatedAt: String,
+    val sportId: Long,
+    val receiverProfileId: String,
+    val gameId: String,
+    val reviewId: String,
+    val reviewer: ReviewerSummary,
+) : SsePayload {
+
+    data class ReviewerSummary(
         val userId: String,
         val nickname: String,
         val tierId: Long,

--- a/src/main/kotlin/org/appjam/smashing/domain/outbox/enums/SseEventType.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/outbox/enums/SseEventType.kt
@@ -17,4 +17,13 @@ enum class SseEventType(
 
     // 매칭 수락 알림 생성
     MATCHING_ACCEPT_NOTIFICATION_CREATED("matching.accept.notification.created"),
+
+    // 게임 관련 변경 사항
+    GAME_UPDATED("game.updated"),
+
+    // 게임 결과 제출 알림 생성
+    GAME_RESULT_SUBMITTED_NOTIFICATION_CREATED("game.result.submitted.notification.created"),
+
+    // 리뷰 제출 알림 생성
+    REVIEW_RECEIVED_NOTIFICATION_CREATED("review.received.notification.created"),
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/review/entity/GameReview.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/review/entity/GameReview.kt
@@ -73,4 +73,21 @@ class GameReview(
     )
     @Comment("경기 IDX")
     var game: Game,
-) : BaseEntity()
+) : BaseEntity() {
+
+    companion object {
+        fun create(
+            game: Game,
+            reviewer: User,
+            reviewee: User,
+            rating: ReviewRating,
+            content: String?,
+        ) = GameReview(
+            game = game,
+            reviewer = reviewer,
+            reviewee = reviewee,
+            rating = rating,
+            content = content,
+        )
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/review/enums/ReviewRating.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/review/enums/ReviewRating.kt
@@ -1,5 +1,7 @@
 package org.appjam.smashing.domain.review.enums
 
 enum class ReviewRating {
-    BAD, GOOD, BEST
+    BAD,  // 별로에요
+    GOOD, // 좋아요
+    BEST  // 최고에요
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/review/service/GameReviewService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/review/service/GameReviewService.kt
@@ -1,0 +1,45 @@
+package org.appjam.smashing.domain.review.service
+
+import org.appjam.smashing.domain.game.repository.GameRepository
+import org.appjam.smashing.domain.review.entity.GameReview
+import org.appjam.smashing.domain.review.enums.ReviewRating
+import org.appjam.smashing.domain.review.enums.ReviewTag
+import org.appjam.smashing.domain.review.repository.GameReviewRepository
+import org.appjam.smashing.domain.user.entity.User
+import org.appjam.smashing.global.exception.CustomException
+import org.appjam.smashing.global.exception.ErrorCode
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class GameReviewService(
+    private val gameRepository: GameRepository,
+    private val gameReviewRepository: GameReviewRepository,
+) {
+
+    @Transactional
+    fun createReview(
+        gameId: String,
+        reviewer: User,
+        reviewee: User,
+        rating: ReviewRating,
+        content: String?,
+        tags: Set<ReviewTag>?,
+    ): GameReview {
+        val game = gameRepository.findByIdOrNull(gameId)
+            ?: throw CustomException(ErrorCode.GAME_NOT_FOUND)
+
+        val review = GameReview.create(
+            game = game,
+            reviewer = reviewer,
+            reviewee = reviewee,
+            rating = rating,
+            content = content,
+        )
+
+        review.tags.addAll(tags.orEmpty())
+
+        return gameReviewRepository.save(review)
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/tier/entity/Tier.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/tier/entity/Tier.kt
@@ -1,4 +1,4 @@
-package org.appjam.smashing.domain.sport.entity
+package org.appjam.smashing.domain.tier.entity
 
 import jakarta.persistence.Column
 import jakarta.persistence.ConstraintMode
@@ -12,6 +12,7 @@ import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import org.appjam.smashing.domain.sport.entity.Sport
 import org.hibernate.annotations.Comment
 
 @Entity

--- a/src/main/kotlin/org/appjam/smashing/domain/tier/repository/TierRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/tier/repository/TierRepository.kt
@@ -1,0 +1,21 @@
+package org.appjam.smashing.domain.tier.repository
+
+import org.appjam.smashing.domain.tier.entity.Tier
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface TierRepository : JpaRepository<Tier, Long> {
+
+    @Query(
+        """
+        select t
+          from Tier t
+         where t.sport.id = :sportId
+           and :lp between t.minLp and t.maxLp
+        """
+    )
+    fun findBySportIdAndLpInRange(
+        sportId: Long,
+        lp: Int,
+    ): Tier?
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/user/entity/UserSportProfile.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/entity/UserSportProfile.kt
@@ -73,4 +73,12 @@ class UserSportProfile(
     ) {
         tier = newTier
     }
+
+    fun recordWin() {
+        wins += 1
+    }
+
+    fun recordLoss() {
+        losses += 1
+    }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/entity/UserSportProfile.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/entity/UserSportProfile.kt
@@ -4,7 +4,7 @@ import io.hypersistence.utils.hibernate.id.Tsid
 import jakarta.persistence.*
 import org.appjam.smashing.domain.common.entity.BaseEntity
 import org.appjam.smashing.domain.sport.entity.Sport
-import org.appjam.smashing.domain.sport.entity.Tier
+import org.appjam.smashing.domain.tier.entity.Tier
 import org.hibernate.annotations.Comment
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
@@ -30,7 +30,7 @@ class UserSportProfile(
 
     @Column(nullable = false)
     @Comment("현재 LP")
-    var lp: Int,
+    var lp: Int = 0,
 
     @Column(nullable = false)
     @Comment("누적 승리 수")
@@ -65,5 +65,12 @@ class UserSportProfile(
         foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT)
     )
     @Comment("현재 티어 IDX")
-    val tier: Tier,
-) : BaseEntity()
+    var tier: Tier,
+) : BaseEntity() {
+
+    fun changeTier(
+        newTier: Tier
+    ) {
+        tier = newTier
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
@@ -1,7 +1,9 @@
 package org.appjam.smashing.domain.user.repository
 
+import jakarta.persistence.LockModeType
 import org.appjam.smashing.domain.user.entity.UserSportProfile
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 
 interface UserSportProfileRepository : JpaRepository<UserSportProfile, String> {
@@ -34,5 +36,22 @@ interface UserSportProfileRepository : JpaRepository<UserSportProfile, String> {
     )
     fun findByIdFetchAll(
         profileId: String,
+    ): UserSportProfile?
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query(
+        """
+        select usp
+          from UserSportProfile usp
+          join fetch usp.user
+          join fetch usp.sport
+          join fetch usp.tier
+         where usp.user.id = :userId
+           and usp.sport.id = :sportId
+        """
+    )
+    fun findByUserIdAndSportIdForUpdate(
+        userId: String,
+        sportId: Long,
     ): UserSportProfile?
 }

--- a/src/main/kotlin/org/appjam/smashing/global/common/validator/EnumValidator.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/common/validator/EnumValidator.kt
@@ -1,0 +1,21 @@
+package org.appjam.smashing.global.common.validator
+
+import jakarta.validation.ConstraintValidator
+import jakarta.validation.ConstraintValidatorContext
+import org.appjam.smashing.global.common.validator.annotation.ValidEnum
+import kotlin.reflect.KClass
+
+class EnumValidator : ConstraintValidator<ValidEnum, String?> {
+
+    private lateinit var enumClass: KClass<out Enum<*>>
+
+    override fun initialize(constraintAnnotation: ValidEnum) {
+        enumClass = constraintAnnotation.enumClass
+    }
+
+    override fun isValid(value: String?, context: ConstraintValidatorContext?): Boolean {
+        if (value.isNullOrBlank()) return true
+
+        return enumClass.java.enumConstants.any { it.name.equals(value, ignoreCase = true) }
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/global/common/validator/annotation/ValidEnum.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/common/validator/annotation/ValidEnum.kt
@@ -1,0 +1,19 @@
+package org.appjam.smashing.global.common.validator.annotation
+
+import jakarta.validation.Constraint
+import jakarta.validation.Payload
+import kotlin.reflect.KClass
+import org.appjam.smashing.global.common.validator.EnumValidator
+
+@Target(
+    AnnotationTarget.FIELD,
+    AnnotationTarget.TYPE
+)
+@Retention(AnnotationRetention.RUNTIME)
+@Constraint(validatedBy = [EnumValidator::class])
+annotation class ValidEnum(
+    val message: String,
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<out Payload>> = [],
+    val enumClass: KClass<out Enum<*>>,
+)

--- a/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
@@ -42,6 +42,9 @@ enum class ErrorCode(
     // Auth - Kakao Token
     INVALID_KAKAO_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-017", "유효하지 않은 카카오 액세스 토큰입니다."),
 
+    // Domain - User / Profile
+    USER_SPORT_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "USER-001", "유저 스포츠 프로필을 찾을 수 없습니다."),
+
     // Domain - Matching
     MATCHING_REQUESTER_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH-001", "요청자 유저를 찾을 수 없습니다."),
     MATCHING_RECEIVER_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH-002", "상대 유저 스포츠 프로필을 찾을 수 없습니다."),
@@ -59,11 +62,18 @@ enum class ErrorCode(
     GAME_REVIEW_ONLY_FIRST_SUBMISSION_ALLOWED(HttpStatus.BAD_REQUEST, "GAME-004", "리뷰는 최초 제출에서만 가능합니다."),
     GAME_RESULT_SUBMIT_BLOCKED_1H(HttpStatus.BAD_REQUEST, "GAME-005", "경기 생성 후 1시간 동안 결과 제출이 불가합니다."),
     GAME_RESULT_SUBMIT_BLOCKED_10M(HttpStatus.BAD_REQUEST, "GAME-006", "연속 경기의 경우 생성 후 10분 동안 결과 제출이 불가합니다."),
-    GAME_RESULT_INVALID_SCORE(HttpStatus.BAD_REQUEST, "GAME-007", "승자 점수는 패자 점수보다 이상이어야 합니다."),
+    GAME_RESULT_INVALID_SCORE(HttpStatus.BAD_REQUEST, "GAME-007", "승자 점수는 패자 점수보다 커야 합니다."),
     GAME_RESULT_SAME_PLAYER(HttpStatus.BAD_REQUEST, "GAME-008", "winnerUserId와 loserUserId는 같을 수 없습니다."),
     GAME_RESULT_ALREADY_SUBMITTED(HttpStatus.BAD_REQUEST, "GAME-009","이미 결과 제출이 진행 중이거나 제출되었습니다."),
     GAME_REVIEW_REQUIRED_ON_FIRST_SUBMISSION(HttpStatus.BAD_REQUEST, "GAME-010","첫 결과 제출에는 리뷰가 필수입니다."),
     GAME_RESULT_SUBMISSION_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "GAME-011","결과 제출은 유저당 최대 2회까지만 가능합니다."),
+    GAME_RESULT_NOT_WAITING_CONFIRMATION(HttpStatus.BAD_REQUEST, "GAME-012", "현재 게임 상태에서는 결과를 확정할 수 없습니다."),
+    GAME_SUBMISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "GAME-013", "경기 결과 제출안을 찾을 수 없습니다."),
+    GAME_SUBMISSION_NOT_SUBMITTED(HttpStatus.BAD_REQUEST, "GAME-014", "이미 처리된 제출안입니다."),
+    GAME_SUBMISSION_CONFIRMER_MISMATCH(HttpStatus.FORBIDDEN, "GAME-015", "해당 제출안을 확정할 권한이 없습니다."),
+
+    // Domain - Tier
+    TIER_NOT_FOUND(HttpStatus.NOT_FOUND, "TIER-001", "LP에 해당하는 티어 정보를 찾을 수 없습니다."),
 
     // Domain - Notification
     NOTIFICATION_TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI-001", "알림 템플릿을 찾을 수 없습니다."),

--- a/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
@@ -52,6 +52,19 @@ enum class ErrorCode(
     MATCHING_FORBIDDEN(HttpStatus.FORBIDDEN, "MATCH-007", "해당 매칭에 대한 권한이 없습니다."),
     MATCHING_ALREADY_RESPONDED(HttpStatus.BAD_REQUEST, "MATCH-008", "이미 응답된 매칭 요청입니다."),
 
+    // Domain - Game
+    GAME_NOT_FOUND(HttpStatus.NOT_FOUND, "GAME-001", "경기를 찾을 수 없습니다."),
+    GAME_FORBIDDEN(HttpStatus.FORBIDDEN, "GAME-002", "경기에 대한 권한이 없습니다."),
+    GAME_RESULT_INVALID_PLAYERS(HttpStatus.BAD_REQUEST, "GAME-003", "승자 또는 패자가 경기 참여자가 아닙니다."),
+    GAME_REVIEW_ONLY_FIRST_SUBMISSION_ALLOWED(HttpStatus.BAD_REQUEST, "GAME-004", "리뷰는 최초 제출에서만 가능합니다."),
+    GAME_RESULT_SUBMIT_BLOCKED_1H(HttpStatus.BAD_REQUEST, "GAME-005", "경기 생성 후 1시간 동안 결과 제출이 불가합니다."),
+    GAME_RESULT_SUBMIT_BLOCKED_10M(HttpStatus.BAD_REQUEST, "GAME-006", "연속 경기의 경우 생성 후 10분 동안 결과 제출이 불가합니다."),
+    GAME_RESULT_INVALID_SCORE(HttpStatus.BAD_REQUEST, "GAME-007", "승자 점수는 패자 점수보다 이상이어야 합니다."),
+    GAME_RESULT_SAME_PLAYER(HttpStatus.BAD_REQUEST, "GAME-008", "winnerUserId와 loserUserId는 같을 수 없습니다."),
+    GAME_RESULT_ALREADY_SUBMITTED(HttpStatus.BAD_REQUEST, "GAME-009","이미 결과 제출이 진행 중이거나 제출되었습니다."),
+    GAME_REVIEW_REQUIRED_ON_FIRST_SUBMISSION(HttpStatus.BAD_REQUEST, "GAME-010","첫 결과 제출에는 리뷰가 필수입니다."),
+    GAME_RESULT_SUBMISSION_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "GAME-011","결과 제출은 유저당 최대 2회까지만 가능합니다."),
+
     // Domain - Notification
     NOTIFICATION_TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI-001", "알림 템플릿을 찾을 수 없습니다."),
 

--- a/src/main/kotlin/org/appjam/smashing/global/extensions/EnumExtensions.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/extensions/EnumExtensions.kt
@@ -1,0 +1,17 @@
+package org.appjam.smashing.global.extensions
+
+inline fun <reified T : Enum<T>> ofIgnoreCase(
+    name: String
+): T {
+    return enumValues<T>().firstOrNull {
+        it.name.equals(name, ignoreCase = true)
+    } ?: throw IllegalArgumentException("No enum constant for name: $name")
+}
+
+inline fun <reified T : Enum<T>> ofIgnoreCaseOrNull(
+    name: String?
+): T? {
+    return enumValues<T>().firstOrNull {
+        it.name.equals(name, ignoreCase = true)
+    }
+}


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #17 

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 경기 결과 제출 api를 작성합니다.

- 현재 저희 서비스 플로우에 맞추어 해당 api에서 결과 제출 생성과 동시에 도메인 규칙 검증 → 게임 상태 변경 → 알림 생성 → SSE 이벤트 전송(Outbox) 까지 하나의 트랜잭션 흐름으로 처리하도록 구성하였습니다.

- 경기 결과 제출 성공 시, 상대(확인자)에게 다음이 함께 발생합니다.
  - Game 상태 변경 (PENDING_RESULT/RESULT_REJECTED → WAITING_CONFIRMATION)
  - GameResultSubmission 생성(제출 회차/제출자·확인자/제출안 기준 승패·점수 포함)
  - Notification 생성
  - SSE 이벤트 전송
  - game.updated : 게임 결과 상태 변경
  - game.result.submitted.notification.created : 결과 제출 알림 생성
  - (최초 제출 시) review.received.notification.created : 후기 알림 생성

- 또한, 결과 제출 흐름에서 발생할 수 있는 충돌을 방지하기 위해 Game 조회 시 PESSIMISTIC_WRITE 락을 적용했습니다. 이를 통해 아래 로직이 동시 요청에서도 일관되게 보장됩니다.
  - 유저당 제출 2회 제한
  - attemptNo(제출 회차) 계산
  - 상태 전환 및 제출 저장 순서

- 도메인 규칙은 서비스 요구사항을 그대로 반영하여 제출 가능 여부를 검증합니다.
  - 상태 규칙: PENDING_RESULT, RESULT_REJECTED 상태에서만 제출 허용 (그 외는 중복 제출로 간주)
  - 권한 규칙: 제출자는 해당 매칭의 requester/receiver 중 1명이어야 함
  - 제출 횟수 제한: 유저당 동일 게임 결과 제출 최대 2회
  - 시간 제약 룰(오늘 00:00 기준)
  - 오늘 확정 0건이면: 게임 생성 후 1시간 동안 제출 불가
  - 오늘 확정 1~2건이면: 직전 확정이 30분 이내인 연속 경기 상황일 때만 게임 생성 후 10분 동안 제출 불가
  - 리뷰 정책: 첫 제출(attemptNo=1)에서만 review 허용 + 필수, 재제출에는 review 입력 불가

- 요청 DTO의 enum 입력 안정성을 위해 @ValidEnum + enum 변환 확장을 함께 적용했습니다.
  - rating은 필수값이므로 @ValidEnum으로 값 자체를 검증하고, 변환은 ofIgnoreCase로 통일했습니다.
  - tags는 다중 입력이며 확장 가능성이 높아, 문자열을 ofIgnoreCaseOrNull로 변환 후 유효한 값만 Set으로 수용하도록 구성했습니다. (즉, 잘못된 태그는 전체 요청 실패 대신 필터링되어 저장되어, 클라이언트 입력 변동에도 API가 안정적으로 동작하도록 했습니다.)


- 경기 결과 수락/확정 API를 작성합니다.

- 경기 결과 확정 성공 시, 시스템에서 다음이 함께 발생합니다.
  - Game.resultStatus 를 WAITING_CONFIRMATION → RESULT_CONFIRMED 로 전환
  - GameResultSubmission.status 를 SUBMITTED → ACCEPTED 로 전환 + actedAt 세팅
  - 승/패에 따라 양쪽 UserSportProfile에 wins/losses, LP, Tier를 일괄 반영

- 최초 제출 -> 후기 작성 SSE 이벤트 전송
- 상태 변경 sse 발행 : game.updated : 제출자(상대)에게 “게임 결과 확정 상태 변경” 전달

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 경기 결과 제출 API 작성
- [x] 경기 결과 확정 API 작성
- [x] 경기 결과 제출안 단건 조회 API 작성

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 경기 결과 제출 API
<img width="1048" height="1204" alt="image" src="https://github.com/user-attachments/assets/d2204f38-80fb-4823-ae30-d306e127e0b8" />
<img width="1092" height="724" alt="image" src="https://github.com/user-attachments/assets/ef26b528-35c0-4032-a792-140d64db344d" />
<img width="1180" height="1290" alt="image" src="https://github.com/user-attachments/assets/ae078a6c-e4b9-48dc-99de-ebe43a2d847d" />
<img width="1030" height="1048" alt="image" src="https://github.com/user-attachments/assets/3a042ccd-8bbc-4244-9ce0-f67c8cacc130" />

- 경기 결과 확정 API
<img width="640" height="490" alt="image" src="https://github.com/user-attachments/assets/630a3f64-3a77-4377-8660-4940fe0cdcda" />

- 경기 결과 제출안 단건 조회 API
<img width="640" height="653" alt="image" src="https://github.com/user-attachments/assets/d0a62bf1-913a-45c6-82db-f05bf343ad8f" />

## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 둘다 api 저희 서비스 정책이 상당히 복잡합니다.....🥺 그만큼 저희 서비스에서 지켜야할 규약들이 있어서 더욱 자세한 내용은 코드나, 노션의 명세에 아주 자세하게 적어두었습니다! 한번 참고해주시면 좋을 것같습니다 🙇‍♀️
- enum 값 검증을 위한 애노테이션과 extension을 만들어두었습니다! 해당 애노테이션과 변환시 extension을 이용해주시면 enum 값 검증을 좀 더 간결하게 하실 수 있습니다 ☺️

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 경기 결과 제출/확정 API 추가 및 제출 상세 조회 지원.
  * 최초 제출 시 리뷰 작성 의무화 및 리뷰 생성/수신 알림 추가.
  * 경기 상태 실시간 업데이트(SSE) 이벤트 및 관련 알림 페이로드 확장.
  * 플레이어 LP/티어 업데이트 반영 및 제출 관련 통지 강화.

* **Bug Fixes**
  * 제출 횟수·시간 제한과 입력 유효성 검사 강화로 부정확한 제출 방지.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->