### PR TITLE
[FEAT] 닉네임 중복 확인 API 구현

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -1,0 +1,27 @@
+package org.appjam.smashing.domain.user.controller
+
+import org.appjam.smashing.domain.user.dto.response.NicknameCheckResponse
+import org.appjam.smashing.domain.user.service.UserService
+import org.appjam.smashing.global.common.dto.ApiResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/users")
+class UserController(
+    private val userService: UserService,
+) {
+    @GetMapping("/nickname-availability")
+    fun checkNicknameAvailability(
+        @RequestParam("nickname") nickname: String,
+    ): ResponseEntity<ApiResponse<NicknameCheckResponse>> {
+        val response = userService.checkNicknameAvailability(nickname)
+
+        return ApiResponse.success(
+            data = response
+        )
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/NicknameCheckResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/NicknameCheckResponse.kt
@@ -1,0 +1,5 @@
+package org.appjam.smashing.domain.user.dto.response
+
+data class NicknameCheckResponse(
+    val available: Boolean,
+)

--- a/src/main/kotlin/org/appjam/smashing/domain/user/entity/User.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/entity/User.kt
@@ -53,6 +53,7 @@ class User(
     fun updateActiveProfile(profileId: String) {
         this.activeUserSportProfileId = profileId
     }
+    
 
     companion object {
         fun create(

--- a/src/main/kotlin/org/appjam/smashing/domain/user/entity/User.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/entity/User.kt
@@ -53,7 +53,6 @@ class User(
     fun updateActiveProfile(profileId: String) {
         this.activeUserSportProfileId = profileId
     }
-    
 
     companion object {
         fun create(

--- a/src/main/kotlin/org/appjam/smashing/domain/user/entity/User.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/entity/User.kt
@@ -9,6 +9,11 @@ import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 
 @Entity
+@Table(
+    indexes = [
+        Index(name = "idx_nickname", columnList = "nickname")
+    ]
+)
 @Comment("유저 정보")
 @SQLRestriction("deleted_at is null")
 @SQLDelete(sql = "update user set deleted_at = now() where id = ?")

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -1,0 +1,25 @@
+package org.appjam.smashing.domain.user.service
+
+import org.appjam.smashing.domain.user.dto.response.NicknameCheckResponse
+import org.appjam.smashing.domain.user.repository.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class UserService(
+    private val userRepository: UserRepository,
+) {
+    @Transactional(readOnly = true)
+    fun checkNicknameAvailability(
+        nickname: String,
+    ): NicknameCheckResponse {
+
+
+        return if (userRepository.existsByNickname(nickname)) {
+            NicknameCheckResponse(false)
+        } else {
+            NicknameCheckResponse(true)
+        }
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -20,7 +20,7 @@ class UserService(
 
         validateNickName(trimmedNickname)
 
-        return if (userRepository.existsByNickname(nickname)) {
+        return if (userRepository.existsByNickname(trimmedNickname)) {
             NicknameCheckResponse(false)
         } else {
             NicknameCheckResponse(true)

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -2,6 +2,8 @@ package org.appjam.smashing.domain.user.service
 
 import org.appjam.smashing.domain.user.dto.response.NicknameCheckResponse
 import org.appjam.smashing.domain.user.repository.UserRepository
+import org.appjam.smashing.global.exception.CustomException
+import org.appjam.smashing.global.exception.ErrorCode
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -14,12 +16,29 @@ class UserService(
     fun checkNicknameAvailability(
         nickname: String,
     ): NicknameCheckResponse {
+        val trimmedNickname = nickname.trim()
 
+        validateNickName(trimmedNickname)
 
         return if (userRepository.existsByNickname(nickname)) {
             NicknameCheckResponse(false)
         } else {
             NicknameCheckResponse(true)
         }
+    }
+
+    private fun validateNickName(trimmedNickname: String) {
+        if (trimmedNickname.length > MAX_NICKNAME_LENGTH) {
+            throw CustomException(ErrorCode.NICKNAME_TOO_LONG)
+        }
+
+        if (!NICKNAME_VALID_REGEX.matches(trimmedNickname)) {
+            throw CustomException(ErrorCode.INVALID_NICKNAME_FORMAT)
+        }
+    }
+
+    companion object {
+        private val NICKNAME_VALID_REGEX = Regex("^[a-zA-Z0-9가-힣]*$")
+        private const val MAX_NICKNAME_LENGTH = 10
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
@@ -47,6 +47,10 @@ enum class ErrorCode(
     // Domain - User / Profile
     USER_SPORT_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "USER-001", "유저 스포츠 프로필을 찾을 수 없습니다."),
 
+    // Domain - User
+    NICKNAME_TOO_LONG(HttpStatus.BAD_REQUEST, "USER-002", "닉네임은 최대 10글자 이하로 가능합니다."),
+    INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST, "USER-003", "특수문자는 사용할 수 없습니다."),
+
     // Domain - Matching
     MATCHING_REQUESTER_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH-001", "요청자 유저를 찾을 수 없습니다."),
     MATCHING_RECEIVER_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH-002", "상대 유저 스포츠 프로필을 찾을 수 없습니다."),


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #24

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 닉네임 중복 API 구현
  - 온보딩에서 유저가 닉네임 입력 시 `existsByNickname`을 이용해 전체 유저 중 동일한 닉네임을 가진 유저가 있는지 확인했습니다.
  - 닉네임 정책을 위반하는 경우(최대 10글자, 특수문자 불가)는 확인하여 400오류를 터트렸습니다. (사전에 클라이언트가 방지한다는 가정 하)
  - 또한 닉네임 중복을 검사할 때마다 `Regex` 객체를 생성하는 것보다는 상수로 미리 컴파일을 해놓는 것이 좋다고 판단하였습니다.
- 고민 사항
  - 요청을 보낼 떄 사용자를 식별하는 `authId`를 따로 헤더에 보내야 되나 고민이 되었는데요.. 
  - 온보딩의 과정이지만 해당 로직은 사용자가 누구인지에 상관 없이 모든 유저를 대상으로 판별하는 API라고 판단하여 별도로 `authId`를 보내는 것 없이 쿼리 파라미터로 닉네임 값만 받도록 했습니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 닉네임 중복 확인 API 구현

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 닉네임 중복 시 응답값

<img width="500" src="https://github.com/user-attachments/assets/113110d6-a990-4696-8ba4-3d812e3af815" />


- 닉네임 중복이 아닐 시 응답값

<img width="500" src="https://github.com/user-attachments/assets/760aa416-1ce4-4cf6-a16e-5e1fc8aa7e76" />


## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 한 가지 우려했던 상황이 있는데 크게 중요하지 않은 것 같아서 넘어가긴 했습니다만 공유를 해보자면.. 
  - 유저 A와 B가 동시에 동일한 닉네임 검증을 하고 A가 B보다 회원가입을 하면 늦게하면 A는 닉네임 중복으로 인해 400오류가 뜨는 경우인데요.. 
  - 사실 이런 경우가 많이 없기도 하고, 그렇다고 닉네임 검증 시에 DB에 저장하는 것도 아닌 것 같아서 일단은 냅뒀습니다...ㅎㅎ 