### PR TITLE
[FEAT] 오픈 채팅 링크 확인 API 구현

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/domain/auth/service/AuthService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/auth/service/AuthService.kt
@@ -12,6 +12,7 @@ import org.appjam.smashing.domain.user.entity.User
 import org.appjam.smashing.domain.user.entity.UserSportProfile
 import org.appjam.smashing.domain.user.repository.UserRepository
 import org.appjam.smashing.domain.user.repository.UserSportProfileRepository
+import org.appjam.smashing.domain.user.service.UserService.Companion.OPEN_CHAT_URL_REGEX
 import org.appjam.smashing.global.auth.jwt.components.JwtProvider
 import org.appjam.smashing.global.exception.CustomException
 import org.appjam.smashing.global.exception.ErrorCode
@@ -63,15 +64,15 @@ class AuthService(
             name = tierName
         ) ?: throw CustomException(ErrorCode.INVALID_TIER_SETTING)
 
-        val trimmedOpenChatUrl = requestCommand.openChatUrl.trim()
-        validateOpenChatUrl(trimmedOpenChatUrl)
+        val trimmedUrl = requestCommand.openChatUrl.trim()
+        validateOpenChatUrl(trimmedUrl)
 
         val user = userRepository.save(
             User.create(
                 kakaoId = requestCommand.authId,
                 nickname = requestCommand.nickname,
                 gender = requestCommand.gender,
-                openchatUrl = trimmedOpenChatUrl,
+                openchatUrl = trimmedUrl,
                 region = requestCommand.region,
             )
         )
@@ -109,9 +110,5 @@ class AuthService(
         if (!OPEN_CHAT_URL_REGEX.matches(trimmedUrl) || trimmedUrl.isBlank()) {
             throw CustomException(ErrorCode.INVALID_OPENCHAT_FORMAT)
         }
-    }
-
-    companion object {
-        private val OPEN_CHAT_URL_REGEX = Regex("^https://open\\.kakao\\.com/o/[a-zA-Z0-9]+\$")
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/command/OpenChatValidateCommand.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/command/OpenChatValidateCommand.kt
@@ -1,0 +1,5 @@
+package org.appjam.smashing.domain.user.command
+
+data class OpenChatValidateCommand(
+    val openchatUrl: String,
+)

--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -1,13 +1,12 @@
 package org.appjam.smashing.domain.user.controller
 
+import org.appjam.smashing.domain.user.dto.request.OpenChatValidateRequest
 import org.appjam.smashing.domain.user.dto.response.NicknameCheckResponse
+import org.appjam.smashing.domain.user.dto.response.OpenChatValidateResponse
 import org.appjam.smashing.domain.user.service.UserService
 import org.appjam.smashing.global.common.dto.ApiResponse
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -19,6 +18,17 @@ class UserController(
         @RequestParam("nickname") nickname: String,
     ): ResponseEntity<ApiResponse<NicknameCheckResponse>> {
         val response = userService.checkNicknameAvailability(nickname)
+
+        return ApiResponse.success(
+            data = response
+        )
+    }
+
+    @PostMapping("/openchat/validate")
+    fun validateOpenChatUrl(
+        @RequestBody openChatValidateRequest: OpenChatValidateRequest,
+    ): ResponseEntity<ApiResponse<OpenChatValidateResponse>> {
+        val response = userService.validateOpenChatUrl(openChatValidateRequest.toCommand())
 
         return ApiResponse.success(
             data = response

--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -1,5 +1,6 @@
 package org.appjam.smashing.domain.user.controller
 
+import jakarta.validation.Valid
 import org.appjam.smashing.domain.user.dto.request.OpenChatValidateRequest
 import org.appjam.smashing.domain.user.dto.response.NicknameCheckResponse
 import org.appjam.smashing.domain.user.dto.response.OpenChatValidateResponse
@@ -26,7 +27,7 @@ class UserController(
 
     @PostMapping("/openchat/validate")
     fun validateOpenChatUrl(
-        @RequestBody openChatValidateRequest: OpenChatValidateRequest,
+        @Valid @RequestBody openChatValidateRequest: OpenChatValidateRequest,
     ): ResponseEntity<ApiResponse<OpenChatValidateResponse>> {
         val response = userService.validateOpenChatUrl(openChatValidateRequest.toCommand())
 

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/request/OpenChatValidateRequest.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/request/OpenChatValidateRequest.kt
@@ -1,0 +1,13 @@
+package org.appjam.smashing.domain.user.dto.request
+
+import jakarta.validation.constraints.NotBlank
+import org.appjam.smashing.domain.user.command.OpenChatValidateCommand
+
+data class OpenChatValidateRequest(
+    @field:NotBlank(message = "openchatUrl을 입력해주세요.")
+    val openchatUrl: String?,
+) {
+    fun toCommand(): OpenChatValidateCommand = OpenChatValidateCommand(
+        openchatUrl = openchatUrl!!,
+    )
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OpenChatValidateResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OpenChatValidateResponse.kt
@@ -1,0 +1,5 @@
+package org.appjam.smashing.domain.user.dto.response
+
+data class OpenChatValidateResponse(
+    val valid: Boolean,
+)

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserRepository.kt
@@ -7,4 +7,5 @@ interface UserRepository : JpaRepository<User, String> {
     fun findByKakaoId(kakaoId: String): User?
     fun existsByKakaoId(kakaoId: String): Boolean
     fun existsByNickname(nickname: String): Boolean
+    fun existsByOpenchatUrl(openChatUrl: String): Boolean
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -64,6 +64,6 @@ class UserService(
     companion object {
         private val NICKNAME_VALID_REGEX = Regex("^[a-zA-Z0-9가-힣]*$")
         private const val MAX_NICKNAME_LENGTH = 10
-        private val OPEN_CHAT_URL_REGEX = Regex("^https://open\\.kakao\\.com/.*$")
+        val OPEN_CHAT_URL_REGEX = Regex("^https://open\\.kakao\\.com/o/[a-zA-Z0-9]+\$")
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -42,11 +42,9 @@ class UserService(
     fun validateOpenChatUrl(
         openChatValidateCommand: OpenChatValidateCommand,
     ): OpenChatValidateResponse {
-        val openChatUrl = openChatValidateCommand.openchatUrl
+        val trimmedUrl = openChatValidateCommand.openchatUrl.trim()
 
-        val trimmedUrl = openChatUrl.trim()
-
-        validateOpenChatUrl(trimmedUrl)
+        checkDuplicateOpenChatUrl(trimmedUrl)
 
         return if (OPEN_CHAT_URL_REGEX.matches(trimmedUrl)) {
             OpenChatValidateResponse(true)
@@ -55,7 +53,7 @@ class UserService(
         }
     }
 
-    private fun validateOpenChatUrl(trimmedUrl: String) {
+    private fun checkDuplicateOpenChatUrl(trimmedUrl: String) {
         if (userRepository.existsByOpenchatUrl(trimmedUrl)) {
             throw CustomException(ErrorCode.DUPLICATE_OPEN_CHAT_URL)
         }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -1,6 +1,8 @@
 package org.appjam.smashing.domain.user.service
 
+import org.appjam.smashing.domain.user.command.OpenChatValidateCommand
 import org.appjam.smashing.domain.user.dto.response.NicknameCheckResponse
+import org.appjam.smashing.domain.user.dto.response.OpenChatValidateResponse
 import org.appjam.smashing.domain.user.repository.UserRepository
 import org.appjam.smashing.global.exception.CustomException
 import org.appjam.smashing.global.exception.ErrorCode
@@ -37,8 +39,31 @@ class UserService(
         }
     }
 
+    fun validateOpenChatUrl(
+        openChatValidateCommand: OpenChatValidateCommand,
+    ): OpenChatValidateResponse {
+        val openChatUrl = openChatValidateCommand.openchatUrl
+
+        val trimmedUrl = openChatUrl.trim()
+
+        validateOpenChatUrl(trimmedUrl)
+
+        return if (OPEN_CHAT_URL_REGEX.matches(trimmedUrl)) {
+            OpenChatValidateResponse(true)
+        } else {
+            OpenChatValidateResponse(false)
+        }
+    }
+
+    private fun validateOpenChatUrl(trimmedUrl: String) {
+        if (userRepository.existsByOpenchatUrl(trimmedUrl)) {
+            throw CustomException(ErrorCode.DUPLICATE_OPEN_CHAT_URL)
+        }
+    }
+
     companion object {
         private val NICKNAME_VALID_REGEX = Regex("^[a-zA-Z0-9가-힣]*$")
         private const val MAX_NICKNAME_LENGTH = 10
+        private val OPEN_CHAT_URL_REGEX = Regex("^https://open\\.kakao\\.com/.*$")
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
@@ -50,6 +50,7 @@ enum class ErrorCode(
     // Domain - User
     NICKNAME_TOO_LONG(HttpStatus.BAD_REQUEST, "USER-002", "닉네임은 최대 10글자 이하로 가능합니다."),
     INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST, "USER-003", "특수문자는 사용할 수 없습니다."),
+    DUPLICATE_OPEN_CHAT_URL(HttpStatus.CONFLICT, "USER-004", "이미 사용중인 오픈채팅방 링크입니다."),
 
     // Domain - Matching
     MATCHING_REQUESTER_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH-001", "요청자 유저를 찾을 수 없습니다."),


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #25

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 오픈 채팅 링크 확인 API 구현
  - 오픈채팅 정규식을 이용해 유효 여부를 검증했습니다.
  - 오픈채팅 링크가 겹치는 경우도 검사하는 게 좋을 것 같아서 넣었습니다.
- 고민사항
  - [닉네임 중복 확인 API](https://github.com/TEAM-SMASHING/SMASHING-SERVER/pull/32)와 같은 고민인데요, `authId`를 헤더에 담아 보낼까 하다가  오픈채팅 링크만 검증하면 될 것 같아서 request body로는 링크만 받는 것으로 구현했습니다!


## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 오픈 채팅 링크 확인 API 구현

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 오픈채팅방 링크가 유효한 경우
<img width="500"  src="https://github.com/user-attachments/assets/b511a408-59b4-4d63-b31e-2a5c7d8a38d5" />

- 오픈채팅방 링크가 유효하지 않은 경우

<img width="500"  src="https://github.com/user-attachments/assets/75627120-367d-44f4-a039-0913b2cc4738" />

## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 혹시 더 검사해야 하는 부분이 있다면 말씀해주세요!