### PR TITLE
[FEAT] 사용자 프로필별 티어 정보 조회 API 구현

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -7,7 +7,6 @@ import org.appjam.smashing.domain.user.dto.response.UserProfileTierResponse
 import org.appjam.smashing.domain.user.service.UserService
 import org.appjam.smashing.global.common.dto.ApiResponse
 import org.springframework.http.ResponseEntity
-import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -39,7 +38,7 @@ class UserController(
 
     @GetMapping("/me/profiles/tier")
     fun getUserProfileTier(
-        @AuthenticationPrincipal userId: String,
+        @RequestHeader("userId") userId: String, // TODO: 인증/인가 회복시 @AuthenticationPrincipal 으로 변경
     ): ResponseEntity<ApiResponse<UserProfileTierResponse>> {
         val response = userService.getUserProfileTier(userId)
 

--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -3,9 +3,11 @@ package org.appjam.smashing.domain.user.controller
 import org.appjam.smashing.domain.user.dto.request.OpenChatValidateRequest
 import org.appjam.smashing.domain.user.dto.response.NicknameCheckResponse
 import org.appjam.smashing.domain.user.dto.response.OpenChatValidateResponse
+import org.appjam.smashing.domain.user.dto.response.UserProfileTierResponse
 import org.appjam.smashing.domain.user.service.UserService
 import org.appjam.smashing.global.common.dto.ApiResponse
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 
 @RestController
@@ -29,6 +31,17 @@ class UserController(
         @RequestBody openChatValidateRequest: OpenChatValidateRequest,
     ): ResponseEntity<ApiResponse<OpenChatValidateResponse>> {
         val response = userService.validateOpenChatUrl(openChatValidateRequest.toCommand())
+
+        return ApiResponse.success(
+            data = response
+        )
+    }
+
+    @GetMapping("/me/profiles/tier")
+    fun getUserProfileTier(
+        @AuthenticationPrincipal userId: String,
+    ): ResponseEntity<ApiResponse<UserProfileTierResponse>> {
+        val response = userService.getUserProfileTier(userId)
 
         return ApiResponse.success(
             data = response

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfileTierResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfileTierResponse.kt
@@ -6,7 +6,7 @@ data class UserProfileTierResponse(
 ) {
     data class ActiveSport(
         val profileId: String,
-        val code: String,
+        val sportCode: String,
         val tier: String,
         val lp: Int,
         val minLp: Int,
@@ -17,6 +17,6 @@ data class UserProfileTierResponse(
 
     data class SportInfo(
         val profileId: String,
-        val code: String,
+        val sportCode: String,
     )
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfileTierResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfileTierResponse.kt
@@ -1,7 +1,7 @@
 package org.appjam.smashing.domain.user.dto.response
 
 data class UserProfileTierResponse(
-    val activeSport: ActiveSport?,
+    val activeSport: ActiveSport,
     val sports: List<SportInfo>,
 ) {
     data class ActiveSport(

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfileTierResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfileTierResponse.kt
@@ -7,7 +7,7 @@ data class UserProfileTierResponse(
     data class ActiveSport(
         val profileId: String,
         val sportCode: String,
-        val tier: String,
+        val tier: Int,
         val lp: Int,
         val minLp: Int,
         val maxLp: Int,
@@ -18,7 +18,7 @@ data class UserProfileTierResponse(
             fun from(
                 profileId: String,
                 sportCode: String,
-                tier: String,
+                tier: Int,
                 lp: Int,
                 minLp: Int,
                 maxLp: Int,

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfileTierResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfileTierResponse.kt
@@ -5,7 +5,6 @@ data class UserProfileTierResponse(
     val sports: List<SportInfo>,
 ) {
     data class ActiveSport(
-
         val profileId: String,
         val code: String,
         val tier: String,

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfileTierResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfileTierResponse.kt
@@ -13,10 +13,42 @@ data class UserProfileTierResponse(
         val maxLp: Int,
         val wins: Int,
         val losses: Int,
-    )
+    ) {
+        companion object {
+            fun from(
+                profileId: String,
+                sportCode: String,
+                tier: String,
+                lp: Int,
+                minLp: Int,
+                maxLp: Int,
+                wins: Int,
+                losses: Int,
+            ) = ActiveSport(
+                profileId = profileId,
+                sportCode = sportCode,
+                tier = tier,
+                lp = lp,
+                minLp = minLp,
+                maxLp = maxLp,
+                wins = wins,
+                losses = losses,
+            )
+        }
+    }
 
     data class SportInfo(
         val profileId: String,
         val sportCode: String,
-    )
+    ) {
+        companion object {
+            fun from(
+                profileId: String,
+                sportCode: String,
+            ) = SportInfo(
+                profileId = profileId,
+                sportCode = sportCode,
+            )
+        }
+    }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfileTierResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfileTierResponse.kt
@@ -1,0 +1,23 @@
+package org.appjam.smashing.domain.user.dto.response
+
+data class UserProfileTierResponse(
+    val activeSport: ActiveSport?,
+    val sports: List<SportInfo>,
+) {
+    data class ActiveSport(
+
+        val profileId: String,
+        val code: String,
+        val tier: String,
+        val lp: Int,
+        val minLp: Int,
+        val maxLp: Int,
+        val wins: Int,
+        val losses: Int,
+    )
+
+    data class SportInfo(
+        val profileId: String,
+        val code: String,
+    )
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
@@ -5,6 +5,7 @@ import org.appjam.smashing.domain.user.entity.UserSportProfile
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface UserSportProfileRepository : JpaRepository<UserSportProfile, String> {
 
@@ -61,11 +62,11 @@ interface UserSportProfileRepository : JpaRepository<UserSportProfile, String> {
             from UserSportProfile usp
             join fetch usp.sport s
             join fetch usp.tier 
-            where usp.user.id = : userId
+            where usp.user.id = :userId
             order by s.name asc
         """
     )
     fun findAllByUserId(
-        userId: String,
+        @Param("userId") userId: String,
     ): List<UserSportProfile>
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
@@ -54,4 +54,18 @@ interface UserSportProfileRepository : JpaRepository<UserSportProfile, String> {
         userId: String,
         sportId: Long,
     ): UserSportProfile?
+
+    @Query(
+        """
+            select usp 
+            from UserSportProfile usp
+            join fetch usp.sport s
+            join fetch usp.tier 
+            where usp.user.id = : userId
+            order by s.name asc
+        """
+    )
+    fun findAllByUserId(
+        userId: String,
+    ): List<UserSportProfile>
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
@@ -5,7 +5,6 @@ import org.appjam.smashing.domain.user.entity.UserSportProfile
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.query.Param
 
 interface UserSportProfileRepository : JpaRepository<UserSportProfile, String> {
 
@@ -67,6 +66,6 @@ interface UserSportProfileRepository : JpaRepository<UserSportProfile, String> {
         """
     )
     fun findAllByUserId(
-        @Param("userId") userId: String,
+        userId: String,
     ): List<UserSportProfile>
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -67,7 +67,7 @@ class UserService(
         userId: String,
     ): UserProfileTierResponse {
         val user = userRepository.findById(userId)
-            .orElseThrow { CustomException(ErrorCode.USER_SPORT_PROFILE_NOT_FOUND) }
+            .orElseThrow { CustomException(ErrorCode.USER_NOT_FOUND) }
 
         val allProfiles = userSportProfileRepository.findAllByUserId(userId)
 

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -79,14 +79,14 @@ class UserService(
             .map {
                 UserProfileTierResponse.SportInfo(
                     profileId = it.id!!,
-                    code = it.sport.code
+                    sportCode = it.sport.code
                 )
             }
 
         return UserProfileTierResponse(
             activeSport = UserProfileTierResponse.ActiveSport(
                 profileId = activeProfile.id!!,
-                code = activeProfile.sport.code,
+                sportCode = activeProfile.sport.code,
                 tier = activeProfile.tier.name,
                 lp = activeProfile.lp,
                 minLp = activeProfile.tier.minLp,

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -3,7 +3,9 @@ package org.appjam.smashing.domain.user.service
 import org.appjam.smashing.domain.user.command.OpenChatValidateCommand
 import org.appjam.smashing.domain.user.dto.response.NicknameCheckResponse
 import org.appjam.smashing.domain.user.dto.response.OpenChatValidateResponse
+import org.appjam.smashing.domain.user.dto.response.UserProfileTierResponse
 import org.appjam.smashing.domain.user.repository.UserRepository
+import org.appjam.smashing.domain.user.repository.UserSportProfileRepository
 import org.appjam.smashing.global.exception.CustomException
 import org.appjam.smashing.global.exception.ErrorCode
 import org.springframework.stereotype.Service
@@ -13,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional
 class UserService(
     private val userRepository: UserRepository,
+    private val userSportProfileRepository: UserSportProfileRepository,
 ) {
     @Transactional(readOnly = true)
     fun checkNicknameAvailability(
@@ -59,6 +62,42 @@ class UserService(
         if (userRepository.existsByOpenchatUrl(trimmedUrl)) {
             throw CustomException(ErrorCode.DUPLICATE_OPEN_CHAT_URL)
         }
+    }
+
+    @Transactional(readOnly = true)
+    fun getUserProfileTier(
+        userId: String,
+    ): UserProfileTierResponse {
+        val user = userRepository.findById(userId)
+            .orElseThrow { CustomException(ErrorCode.USER_SPORT_PROFILE_NOT_FOUND) }
+
+        val allProfiles = userSportProfileRepository.findAllByUserId(userId)
+
+        val activeProfile = allProfiles.find { it.id == user.activeUserSportProfileId }
+            ?: throw CustomException(ErrorCode.ACTIVE_PROFILE_NOT_FOUND)
+
+        val sportsList = allProfiles
+            .filter { it.id != user.activeUserSportProfileId }
+            .map {
+                UserProfileTierResponse.SportInfo(
+                    profileId = it.id!!,
+                    code = it.sport.code
+                )
+            }
+
+        return UserProfileTierResponse(
+            activeSport = UserProfileTierResponse.ActiveSport(
+                profileId = activeProfile.id!!,
+                code = activeProfile.sport.code,
+                tier = activeProfile.tier.name,
+                lp = activeProfile.lp,
+                minLp = activeProfile.tier.minLp,
+                maxLp = activeProfile.tier.maxLp,
+                wins = activeProfile.wins,
+                losses = activeProfile.losses
+            ),
+            sports = sportsList
+        )
     }
 
     companion object {

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -8,6 +8,7 @@ import org.appjam.smashing.domain.user.repository.UserRepository
 import org.appjam.smashing.domain.user.repository.UserSportProfileRepository
 import org.appjam.smashing.global.exception.CustomException
 import org.appjam.smashing.global.exception.ErrorCode
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -66,8 +67,8 @@ class UserService(
     fun getUserProfileTier(
         userId: String,
     ): UserProfileTierResponse {
-        val user = userRepository.findById(userId)
-            .orElseThrow { CustomException(ErrorCode.USER_NOT_FOUND) }
+        val user = userRepository.findByIdOrNull(userId)
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
         val allProfiles = userSportProfileRepository.findAllByUserId(userId)
 

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -77,14 +77,14 @@ class UserService(
         val sportsList = allProfiles
             .filter { it.id != user.activeUserSportProfileId }
             .map {
-                UserProfileTierResponse.SportInfo(
+                UserProfileTierResponse.SportInfo.from(
                     profileId = it.id!!,
                     sportCode = it.sport.code
                 )
             }
 
         return UserProfileTierResponse(
-            activeSport = UserProfileTierResponse.ActiveSport(
+            activeSport = UserProfileTierResponse.ActiveSport.from(
                 profileId = activeProfile.id!!,
                 sportCode = activeProfile.sport.code,
                 tier = activeProfile.tier.name,

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -87,7 +87,7 @@ class UserService(
             activeSport = UserProfileTierResponse.ActiveSport.from(
                 profileId = activeProfile.id!!,
                 sportCode = activeProfile.sport.code,
-                tier = activeProfile.tier.name,
+                tier = activeProfile.tier.orderNo,
                 lp = activeProfile.lp,
                 minLp = activeProfile.tier.minLp,
                 maxLp = activeProfile.tier.maxLp,

--- a/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
@@ -46,11 +46,12 @@ enum class ErrorCode(
 
     // Domain - User / Profile
     USER_SPORT_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "USER-001", "유저 스포츠 프로필을 찾을 수 없습니다."),
+    ACTIVE_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "USER-002", "활성화된 유저 스포츠 프로필을 찾을 수 없습니다."),
 
     // Domain - User
-    NICKNAME_TOO_LONG(HttpStatus.BAD_REQUEST, "USER-002", "닉네임은 최대 10글자 이하로 가능합니다."),
-    INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST, "USER-003", "특수문자는 사용할 수 없습니다."),
-    DUPLICATE_OPEN_CHAT_URL(HttpStatus.CONFLICT, "USER-004", "이미 사용중인 오픈채팅방 링크입니다."),
+    NICKNAME_TOO_LONG(HttpStatus.BAD_REQUEST, "USER-003", "닉네임은 최대 10글자 이하로 가능합니다."),
+    INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST, "USER-004", "특수문자는 사용할 수 없습니다."),
+    DUPLICATE_OPEN_CHAT_URL(HttpStatus.CONFLICT, "USER-005", "이미 사용중인 오픈채팅방 링크입니다."),
 
     // Domain - Matching
     MATCHING_REQUESTER_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH-001", "요청자 유저를 찾을 수 없습니다."),

--- a/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
@@ -49,10 +49,11 @@ enum class ErrorCode(
     ACTIVE_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "USER-002", "활성화된 유저 스포츠 프로필을 찾을 수 없습니다."),
 
     // Domain - User
-    NICKNAME_TOO_LONG(HttpStatus.BAD_REQUEST, "USER-003", "닉네임은 최대 10글자 이하로 가능합니다."),
-    INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST, "USER-004", "특수문자는 사용할 수 없습니다."),
-    DUPLICATE_OPEN_CHAT_URL(HttpStatus.CONFLICT, "USER-005", "이미 사용중인 오픈채팅방 링크입니다."),
-    INVALID_OPENCHAT_FORMAT(HttpStatus.BAD_REQUEST, "USER-006", "잘못된 오픈채팅 링크 형식입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER-003", "유저를 찾을 수 없습니다."),
+    NICKNAME_TOO_LONG(HttpStatus.BAD_REQUEST, "USER-004", "닉네임은 최대 10글자 이하로 가능합니다."),
+    INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST, "USER-005", "특수문자는 사용할 수 없습니다."),
+    DUPLICATE_OPEN_CHAT_URL(HttpStatus.CONFLICT, "USER-006", "이미 사용중인 오픈채팅방 링크입니다."),
+    INVALID_OPENCHAT_FORMAT(HttpStatus.BAD_REQUEST, "USER-007", "잘못된 오픈채팅 링크 형식입니다."),
 
     // Domain - Matching
     MATCHING_REQUESTER_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH-001", "요청자 유저를 찾을 수 없습니다."),


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #26

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 사용자 프로필별 티어 정보 조회 API 구현
  - `userId`를 이용해 사용자의 스포츠 프로필에 대한 모든 정보를 join fetch를 통해 가져옵니다.
  - 이때 활성화 된 스포츠가 가장 앞으로 오고, 나머지 비활성화 스포츠는 가나다 순 정렬이므로 `order by s.name asc`를 추가해 모든 정보를 정렬된 순으로 가져왔습니다.
  - 최종적으로 비활성화 스포츠 리스트에서는 활성화된 스포츠만 제거해 응답값으로 반환해주었습니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 사용자 프로필별 티어 정보 조회 API 구현

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
<img width="597" height="494" alt="image" src="https://github.com/user-attachments/assets/ac86bbcb-fa93-4ff2-bb7e-c916bf19cb16" />


## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 하나의 트러블 슈팅을 적자면 레포지토리 쿼리문에 `where usp.user.id = :userId`를 적는데 띄어쓰기를 잘못해서 `: userId`라고 쓰면 오류가 나더라구요.... 이것 때문에 꽤 당황을 했었어서 사소하지만 중요한 부분이었습니다..
- 추가로 인증/인가 부분이 처리되지 않은 부분은 시큐리티 설정을 해줘야 할까요..?