### PR TITLE
[FEAT/ 경기 결과 제출안 거절 API, 경기 삭제 API 작성

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/domain/game/controller/GameController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/controller/GameController.kt
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.appjam.smashing.domain.game.dto.request.GameResultConfirmRequest
+import org.appjam.smashing.domain.game.dto.request.GameResultRejectRequest
 import org.appjam.smashing.domain.game.dto.request.GameResultSubmitRequest
 import org.appjam.smashing.domain.game.dto.response.GameResultSubmissionDetailResponse
 import org.appjam.smashing.domain.game.service.GameService
@@ -112,5 +113,33 @@ class GameController(
         )
 
         return ApiResponse.success(response)
+    }
+
+    @Operation(
+        summary = "경기 결과 거절 API",
+        description = """
+            상대가 제출한 경기 결과 제출안(submission)을 거절합니다.
+            - 거절은 submission.confirmer(받은 사람)만 가능합니다.
+            - 상태 변경 sse가 발행됩니다.
+            - 거절 사유에 따라 NotificationType이 분리되어 전송됩니다. (알림+sse)
+              - SCORE_MISMATCH -> RESULT_REJECTED_SCORE_MISMATCH
+              - WIN_LOSE_REVERSED -> RESULT_REJECTED_WIN_LOSE_REVERSED
+        """
+    )
+    @PostMapping("/{gameId}/submissions/{submissionId}/reject")
+    fun rejectGameResult(
+        @RequestHeader("userId") confirmerUserId: String, // TODO: 인증/인가 적용시 변경
+        @PathVariable gameId: String,
+        @PathVariable submissionId: String,
+        @Valid @RequestBody request: GameResultRejectRequest,
+    ): ResponseEntity<ApiResponse<Unit>> {
+        gameService.rejectResult(
+            confirmerUserId = confirmerUserId,
+            gameId = gameId,
+            submissionId = submissionId,
+            command = request.toCommand(),
+        )
+
+        return ApiResponse.success()
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/game/controller/GameController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/controller/GameController.kt
@@ -142,4 +142,28 @@ class GameController(
 
         return ApiResponse.success()
     }
+
+    @Operation(
+        summary = "경기 삭제 API",
+        description = """
+            경기를 삭제(soft delete)합니다.
+            - 게임의 resultStatus를 CANCELED로 변경.
+            - 단, RESULT_CONFIRMED(확정) 상태면 삭제 불가
+            - 삭제 시 제출안(GameResultSubmission)도 함께 soft delete 처리.
+            - 경기 참여자(매칭 requester/receiver)만 삭제 가능
+            - 게임 상태 변경 SSE(game.updated)가 상대에게 발행. (resultStatus = CANCELED)
+        """
+    )
+    @DeleteMapping("/{gameId}")
+    fun deleteGame(
+        @RequestHeader("userId") userId: String, // TODO: 인증/인가 적용시 변경
+        @PathVariable gameId: String,
+    ): ResponseEntity<ApiResponse<Unit>> {
+        gameService.deleteGame(
+            userId = userId,
+            gameId = gameId,
+        )
+
+        return ApiResponse.success()
+    }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/game/dto/command/GameResultRejectCommand.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/dto/command/GameResultRejectCommand.kt
@@ -1,0 +1,7 @@
+package org.appjam.smashing.domain.game.dto.command
+
+import org.appjam.smashing.domain.game.enums.GameResultRejectReason
+
+data class GameResultRejectCommand(
+    val reason: GameResultRejectReason,
+)

--- a/src/main/kotlin/org/appjam/smashing/domain/game/dto/request/GameResultRejectRequest.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/dto/request/GameResultRejectRequest.kt
@@ -1,0 +1,17 @@
+package org.appjam.smashing.domain.game.dto.request
+
+import jakarta.validation.constraints.NotBlank
+import org.appjam.smashing.domain.game.dto.command.GameResultRejectCommand
+import org.appjam.smashing.domain.game.enums.GameResultRejectReason
+import org.appjam.smashing.global.common.validator.annotation.ValidEnum
+import org.appjam.smashing.global.extensions.ofIgnoreCase
+
+data class GameResultRejectRequest(
+    @field:NotBlank(message = "reason은 필수입니다.")
+    @field:ValidEnum(message = "잘못된 reason 값입니다.", enumClass = GameResultRejectReason::class)
+    val reason: String?,
+) {
+    fun toCommand() = GameResultRejectCommand(
+        reason = ofIgnoreCase<GameResultRejectReason>(reason!!),
+    )
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/game/entity/Game.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/entity/Game.kt
@@ -114,6 +114,10 @@ class Game(
         resultStatus = GameResultStatus.WAITING_CONFIRMATION
     }
 
+    fun markRejected() {
+        resultStatus = GameResultStatus.RESULT_REJECTED
+    }
+
     fun confirmResult(
         submissionId: String,
         winner: User,

--- a/src/main/kotlin/org/appjam/smashing/domain/game/entity/Game.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/entity/Game.kt
@@ -14,6 +14,7 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 import org.appjam.smashing.domain.common.entity.BaseEntity
 import org.appjam.smashing.domain.matching.entity.Matching
 import org.appjam.smashing.domain.game.enums.GameResultStatus
@@ -26,6 +27,9 @@ import java.time.LocalDateTime
 
 @Entity
 @Table(
+    uniqueConstraints = [
+        UniqueConstraint(name = "uk_game_matching_id", columnNames = ["matching_id"])
+    ],
     indexes = [
         Index(name = "idx_game_matching_id", columnList = "matching_id"),
         Index(name = "idx_game_sport_id", columnList = "sport_id"),

--- a/src/main/kotlin/org/appjam/smashing/domain/game/entity/Game.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/entity/Game.kt
@@ -138,4 +138,8 @@ class Game(
         this.scoreLoser = scoreLoser
         this.confirmedAt = confirmedAt
     }
+
+    fun cancel() {
+        resultStatus = GameResultStatus.CANCELED
+    }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/game/entity/GameResultSubmission.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/entity/GameResultSubmission.kt
@@ -3,7 +3,7 @@ package org.appjam.smashing.domain.game.entity
 import io.hypersistence.utils.hibernate.id.Tsid
 import jakarta.persistence.*
 import org.appjam.smashing.domain.common.entity.BaseEntity
-import org.appjam.smashing.domain.game.enums.RejectReason
+import org.appjam.smashing.domain.game.enums.GameResultRejectReason
 import org.appjam.smashing.domain.game.enums.SubmissionStatus
 import org.appjam.smashing.domain.user.entity.User
 import org.hibernate.annotations.Comment
@@ -55,7 +55,7 @@ class GameResultSubmission(
     @Enumerated(EnumType.STRING)
     @Column(name = "reject_reason", columnDefinition = "VARCHAR(30)")
     @Comment("거절 사유")
-    var rejectReason: RejectReason? = null,
+    var gameResultRejectReason: GameResultRejectReason? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(
@@ -129,6 +129,15 @@ class GameResultSubmission(
         actedAt: LocalDateTime
     ) {
         status = SubmissionStatus.ACCEPTED
+        this.actedAt = actedAt
+    }
+
+    fun reject(
+        reason: GameResultRejectReason,
+        actedAt: LocalDateTime,
+    ) {
+        status = SubmissionStatus.REJECTED
+        gameResultRejectReason = reason
         this.actedAt = actedAt
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/game/enums/GameResultRejectReason.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/enums/GameResultRejectReason.kt
@@ -1,6 +1,6 @@
 package org.appjam.smashing.domain.game.enums
 
-enum class RejectReason {
+enum class GameResultRejectReason {
     SCORE_MISMATCH,      // 점수 불일치
     WIN_LOSE_REVERSED    // 승패 반전
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepository.kt
@@ -70,4 +70,16 @@ interface GameRepository : JpaRepository<Game, String> {
         userA: String,
         userB: String,
     ): LocalDateTime?
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query(
+        """
+        select g
+        from Game g
+        where g.id = :gameId
+        """
+    )
+    fun findByIdForUpdate(
+        gameId: String,
+    ): Game?
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepository.kt
@@ -82,4 +82,17 @@ interface GameRepository : JpaRepository<Game, String> {
     fun findByIdForUpdate(
         gameId: String,
     ): Game?
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query(
+        """
+        select g
+          from Game g
+          join fetch g.matching m
+          join fetch m.requester
+          join fetch m.receiver
+         where g.id = :gameId
+        """
+    )
+    fun findByIdFetchUsersForUpdate(gameId: String): Game?
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameResultSubmissionRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameResultSubmissionRepository.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.LockModeType
 import org.appjam.smashing.domain.game.entity.GameResultSubmission
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 
 interface GameResultSubmissionRepository : JpaRepository<GameResultSubmission, String> {
@@ -44,4 +45,16 @@ interface GameResultSubmissionRepository : JpaRepository<GameResultSubmission, S
         submissionId: String,
         gameId: String,
     ): GameResultSubmission?
+
+    @Modifying
+    @Query(
+        """
+        update GameResultSubmission s
+           set s.deletedAt = CURRENT_TIMESTAMP
+         where s.game.id = :gameId
+        """
+    )
+    fun softDeleteAllByGameId(
+        gameId: String
+    ): Int
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
@@ -317,6 +317,63 @@ class GameService(
         )
     }
 
+    @Transactional
+    fun deleteGame(
+        userId: String,
+        gameId: String,
+    ) {
+        // 게임 조회(잠금)
+        val game = gameRepository.findByIdFetchUsersForUpdate(gameId)
+            ?: throw CustomException(ErrorCode.GAME_NOT_FOUND)
+
+        // 삭제 가능 상태 검증
+        validateDeletable(game.resultStatus)
+
+        // 상대방 userId 조회
+        val opponentUserId = resolveOpponentUserId(
+            requesterId = game.matching.requester.id!!,
+            receiverId = game.matching.receiver.id!!,
+            userId = userId,
+        )
+
+        // 게임 취소 처리
+        game.cancel()
+        gameRepository.flush()
+
+        // submissions soft delete
+        submissionRepository.softDeleteAllByGameId(gameId)
+
+        // game soft delete
+        gameRepository.delete(game)
+
+        // 게임 상태 변경 SSE 발행
+        publishGameUpdated(
+            receiverUserId = opponentUserId,
+            gameId = game.id!!,
+            resultStatus = game.resultStatus,
+        )
+    }
+
+    private fun validateDeletable(
+        resultStatus: GameResultStatus
+    ) {
+        if (resultStatus == GameResultStatus.RESULT_CONFIRMED) {
+            throw CustomException(ErrorCode.GAME_RESULT_ALREADY_CONFIRMED)
+        }
+    }
+
+    private fun resolveOpponentUserId(
+        requesterId: String,
+        receiverId: String,
+        userId: String,
+    ): String {
+        return when (userId) {
+            requesterId -> receiverId
+            receiverId -> requesterId
+            else -> throw CustomException(ErrorCode.GAME_FORBIDDEN)
+        }
+    }
+
     private fun scoreOf(
         submission: GameResultSubmission,
         userId: String,

--- a/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
@@ -1,10 +1,12 @@
 package org.appjam.smashing.domain.game.service
 
 import org.appjam.smashing.domain.game.dto.command.GameResultConfirmCommand
+import org.appjam.smashing.domain.game.dto.command.GameResultRejectCommand
 import org.appjam.smashing.domain.game.dto.command.GameResultSubmitCommand
 import org.appjam.smashing.domain.game.dto.response.GameResultSubmissionDetailResponse
 import org.appjam.smashing.domain.game.entity.Game
 import org.appjam.smashing.domain.game.entity.GameResultSubmission
+import org.appjam.smashing.domain.game.enums.GameResultRejectReason
 import org.appjam.smashing.domain.game.enums.GameResultStatus
 import org.appjam.smashing.domain.game.enums.SubmissionStatus
 import org.appjam.smashing.domain.game.repository.GameRepository
@@ -12,6 +14,7 @@ import org.appjam.smashing.domain.game.repository.GameResultSubmissionRepository
 import org.appjam.smashing.domain.notification.enums.NotificationType
 import org.appjam.smashing.domain.notification.service.NotificationService
 import org.appjam.smashing.domain.outbox.components.OutboxEventPublisher
+import org.appjam.smashing.domain.outbox.dto.GameResultRejectedNotificationCreatedPayload
 import org.appjam.smashing.domain.outbox.dto.GameResultSubmittedNotificationCreatedPayload
 import org.appjam.smashing.domain.outbox.dto.GameUpdatedPayload
 import org.appjam.smashing.domain.outbox.dto.ReviewReceivedNotificationCreatedPayload
@@ -208,6 +211,7 @@ class GameService(
             ?: throw CustomException(ErrorCode.USER_SPORT_PROFILE_NOT_FOUND)
 
         // 승자/패자 프로필 업데이트 (승리/패배 수 + LP + 티어)
+        // TODO: 추후 lp 기록 쌓이는 로직 추가 필요
         val winnerProfile = if (submission.winner.id == submission.submitter.id) submitterProfile else confirmerProfile
         val loserProfile = if (submission.loser.id == submission.submitter.id) submitterProfile else confirmerProfile
 
@@ -251,6 +255,65 @@ class GameService(
             submission = submission,
             winnerScore = winnerScore,
             loserScore = loserScore,
+        )
+    }
+
+    @Transactional
+    fun rejectResult(
+        confirmerUserId: String,
+        gameId: String,
+        submissionId: String,
+        command: GameResultRejectCommand,
+    ) {
+        val now = LocalDateTime.now(DEFAULT_ZONE_ID) // TODO: 인증인가 회복시 변경
+
+        // 게임 조회(잠금)
+        val game = gameRepository.findByIdForUpdate(gameId)
+            ?: throw CustomException(ErrorCode.GAME_NOT_FOUND)
+
+        // 경기 상태 검증
+        if (game.resultStatus != GameResultStatus.WAITING_CONFIRMATION) {
+            throw CustomException(ErrorCode.GAME_RESULT_NOT_WAITING_CONFIRMATION)
+        }
+
+        // 제출안 조회(잠금)
+        val submission = submissionRepository.findByIdAndGameIdForUpdate(submissionId, gameId)
+            ?: throw CustomException(ErrorCode.GAME_SUBMISSION_NOT_FOUND)
+
+        // 제출안 상태 검증
+        if (submission.status != SubmissionStatus.SUBMITTED) {
+            throw CustomException(ErrorCode.GAME_SUBMISSION_NOT_SUBMITTED)
+        }
+
+        // 받은 사람만 거절 가능
+        if (submission.confirmer.id != confirmerUserId) {
+            throw CustomException(ErrorCode.GAME_SUBMISSION_CONFIRMER_MISMATCH)
+        }
+
+        // 상태 변경
+        game.markRejected()
+        submission.reject(
+            reason = command.reason,
+            actedAt = now,
+        )
+
+        val sportId = game.sport.id!!
+
+        // 게임 상태 변경 SSE 발행
+        publishGameUpdated(
+            receiverUserId = submission.submitter.id!!,
+            gameId = game.id!!,
+            resultStatus = game.resultStatus,
+        )
+
+        // 결과 거절 알림 + SSE 발행
+        notifyGameResultRejected(
+            receiver = submission.submitter,
+            rejector = submission.confirmer,
+            gameId = game.id!!,
+            submissionId = submission.id!!,
+            sportId = sportId,
+            reason = command.reason,
         )
     }
 
@@ -527,6 +590,64 @@ class GameService(
             payload = GameUpdatedPayload(
                 gameId = gameId,
                 resultStatus = resultStatus,
+            )
+        )
+    }
+
+    private fun notifyGameResultRejected(
+        receiver: User,
+        rejector: User,
+        gameId: String,
+        submissionId: String,
+        sportId: Long,
+        reason: GameResultRejectReason,
+    ) {
+        val receiverProfileId = userSportProfileRepository.findProfileIdByUserIdAndSportId(
+            userId = receiver.id!!,
+            sportId = sportId,
+        ) ?: throw CustomException(ErrorCode.USER_SPORT_PROFILE_NOT_FOUND)
+
+        val rejectorTierId = userSportProfileRepository.findTierIdByUserIdAndSportId(
+            userId = rejector.id!!,
+            sportId = sportId,
+        ) ?: throw CustomException(ErrorCode.USER_SPORT_PROFILE_NOT_FOUND)
+
+        val notificationType = when (reason) {
+            GameResultRejectReason.SCORE_MISMATCH -> NotificationType.RESULT_REJECTED_SCORE_MISMATCH
+            GameResultRejectReason.WIN_LOSE_REVERSED -> NotificationType.RESULT_REJECTED_WIN_LOSE_REVERSED
+        }
+
+        val notification = notificationService.createResultRejected(
+            receiver = receiver,
+            notificationType = notificationType,
+            gameId = gameId,
+            submissionId = submissionId,
+            rejectorNickname = rejector.nickname,
+            rejectorTierId = rejectorTierId,
+        )
+
+        val notificationCreatedAt = notification.createdAt
+            .atZone(DEFAULT_ZONE_ID)
+            .toOffsetDateTime()
+            .toString()
+
+        outboxEventPublisher.publish(
+            userId = receiver.id!!,
+            eventType = SseEventType.GAME_RESULT_REJECTED_NOTIFICATION_CREATED,
+            payload = GameResultRejectedNotificationCreatedPayload(
+                notificationId = notification.id!!,
+                notificationType = notificationType,
+                notificationCreatedAt = notificationCreatedAt,
+                sportId = sportId,
+                receiverProfileId = receiverProfileId,
+                gameId = gameId,
+                submissionId = submissionId,
+                reason = reason,
+                rejector = GameResultRejectedNotificationCreatedPayload.RejectorSummary(
+                    userId = rejector.id!!,
+                    nickname = rejector.nickname,
+                    tierId = rejectorTierId,
+                ),
             )
         )
     }

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepository.kt
@@ -1,23 +1,26 @@
 package org.appjam.smashing.domain.matching.repository
 
+import jakarta.persistence.LockModeType
 import org.appjam.smashing.domain.matching.entity.Matching
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
-import java.time.LocalDateTime
 
 interface MatchingRepository : JpaRepository<Matching, String> {
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query(
         """
         select m
-          from Matching m
-          join fetch m.requester
-          join fetch m.receiver
-          join fetch m.sport
-         where m.id = :matchingId
+        from Matching m
+        join fetch m.requester
+        join fetch m.receiver
+        join fetch m.sport
+        where m.id = :matchingId
+          and m.deletedAt is null
         """
     )
-    fun findByIdFetchAll(
+    fun findByIdFetchAllForUpdate(
         matchingId: String
     ): Matching?
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
@@ -110,7 +110,7 @@ class MatchingService(
         receiverUserId: String,
         matchingId: String,
     ) {
-        val matching = matchingRepository.findByIdFetchAll(matchingId)
+        val matching = matchingRepository.findByIdFetchAllForUpdate(matchingId)
             ?: throw CustomException(ErrorCode.MATCHING_NOT_FOUND)
 
         // 수락 가능 여부 검증
@@ -162,7 +162,7 @@ class MatchingService(
         receiverUserId: String,
         matchingId: String,
     ) {
-        val matching = matchingRepository.findByIdFetchAll(matchingId)
+        val matching = matchingRepository.findByIdFetchAllForUpdate(matchingId)
             ?: throw CustomException(ErrorCode.MATCHING_NOT_FOUND)
 
         validateRejectable(matching, receiverUserId)
@@ -186,7 +186,7 @@ class MatchingService(
         requesterUserId: String,
         matchingId: String,
     ) {
-        val matching = matchingRepository.findByIdFetchAll(matchingId)
+        val matching = matchingRepository.findByIdFetchAllForUpdate(matchingId)
             ?: throw CustomException(ErrorCode.MATCHING_NOT_FOUND)
 
         validateCancellableByRequester(matching, requesterUserId)

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/entity/Notification.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/entity/Notification.kt
@@ -3,6 +3,7 @@ package org.appjam.smashing.domain.notification.entity
 import io.hypersistence.utils.hibernate.id.Tsid
 import jakarta.persistence.*
 import org.appjam.smashing.domain.common.entity.BaseEntity
+import org.appjam.smashing.domain.game.enums.GameResultRejectReason
 import org.appjam.smashing.domain.user.entity.User
 import org.appjam.smashing.domain.user.entity.UserSportProfile
 import org.hibernate.annotations.Comment
@@ -108,6 +109,36 @@ class Notification(
             params = """{"reviewerNickname":"$reviewerNickname","reviewerTierId":$reviewerTierId,"reviewId":"$reviewId","gameId":"$gameId"}""",
             isRead = false,
             linkUrl = "/api/v1/reviews/$reviewId",
+            user = receiver,
+            notificationTemplate = template,
+        )
+
+        fun createResultRejectedScoreMismatch(
+            receiver: User,
+            template: NotificationTemplate,
+            gameId: String,
+            submissionId: String,
+            rejectorNickname: String,
+            rejectorTierId: Long,
+        ) = Notification(
+            params = """{"rejectorNickname":"$rejectorNickname","rejectorTierId":$rejectorTierId,"gameId":"$gameId","submissionId":"$submissionId","reason":"${GameResultRejectReason.SCORE_MISMATCH.name}"}""",
+            isRead = false,
+            linkUrl = "/api/v1/users/me/matchings/accepted/pending-result",
+            user = receiver,
+            notificationTemplate = template,
+        )
+
+        fun createResultRejectedWinLoseReversed(
+            receiver: User,
+            template: NotificationTemplate,
+            gameId: String,
+            submissionId: String,
+            rejectorNickname: String,
+            rejectorTierId: Long,
+        ) = Notification(
+            params = """{"rejectorNickname":"$rejectorNickname","rejectorTierId":$rejectorTierId,"gameId":"$gameId","submissionId":"$submissionId","reason":"${GameResultRejectReason.WIN_LOSE_REVERSED.name}"}""",
+            isRead = false,
+            linkUrl = "/api/v1/users/me/matchings/accepted/pending-result",
             user = receiver,
             notificationTemplate = template,
         )

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/service/NotificationService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/service/NotificationService.kt
@@ -91,4 +91,42 @@ class NotificationService(
             )
         )
     }
+
+    fun createResultRejected(
+        receiver: User,
+        notificationType: NotificationType,
+        gameId: String,
+        submissionId: String,
+        rejectorNickname: String,
+        rejectorTierId: Long,
+    ): Notification {
+        val template = notificationTemplateRepository.findByType(notificationType)
+            ?: throw CustomException(ErrorCode.NOTIFICATION_TEMPLATE_NOT_FOUND)
+
+        val notification = when (notificationType) {
+            NotificationType.RESULT_REJECTED_SCORE_MISMATCH ->
+                Notification.createResultRejectedScoreMismatch(
+                    receiver = receiver,
+                    template = template,
+                    gameId = gameId,
+                    submissionId = submissionId,
+                    rejectorNickname = rejectorNickname,
+                    rejectorTierId = rejectorTierId,
+                )
+
+            NotificationType.RESULT_REJECTED_WIN_LOSE_REVERSED ->
+                Notification.createResultRejectedWinLoseReversed(
+                    receiver = receiver,
+                    template = template,
+                    gameId = gameId,
+                    submissionId = submissionId,
+                    rejectorNickname = rejectorNickname,
+                    rejectorTierId = rejectorTierId,
+                )
+
+            else -> throw CustomException(ErrorCode.NOTIFICATION_RESULT_REJECTED_TYPE_MISMATCH)
+        }
+
+        return notificationRepository.save(notification)
+    }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/outbox/dto/SsePayload.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/outbox/dto/SsePayload.kt
@@ -1,5 +1,6 @@
 package org.appjam.smashing.domain.outbox.dto
 
+import org.appjam.smashing.domain.game.enums.GameResultRejectReason
 import org.appjam.smashing.domain.game.enums.GameResultStatus
 import org.appjam.smashing.domain.notification.enums.NotificationType
 import org.appjam.smashing.domain.outbox.enums.MatchingUpdateStatus
@@ -139,6 +140,30 @@ data class ReviewReceivedNotificationCreatedPayload(
 ) : SsePayload {
 
     data class ReviewerSummary(
+        val userId: String,
+        val nickname: String,
+        val tierId: Long,
+    )
+}
+
+/**
+ * 경기 결과 거절 알림 생성
+ * - 상대가 나의 결과 제출을 거절한 순간 알림 생성
+ */
+data class GameResultRejectedNotificationCreatedPayload(
+    override val type: String = SseEventType.GAME_RESULT_REJECTED_NOTIFICATION_CREATED.eventName,
+    val notificationId: String,
+    val notificationType: NotificationType,
+    val notificationCreatedAt: String,
+    val sportId: Long,
+    val receiverProfileId: String,
+    val gameId: String,
+    val submissionId: String,
+    val reason: GameResultRejectReason,
+    val rejector: RejectorSummary,
+) : SsePayload {
+
+    data class RejectorSummary(
         val userId: String,
         val nickname: String,
         val tierId: Long,

--- a/src/main/kotlin/org/appjam/smashing/domain/outbox/enums/SseEventType.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/outbox/enums/SseEventType.kt
@@ -24,6 +24,9 @@ enum class SseEventType(
     // 게임 결과 제출 알림 생성
     GAME_RESULT_SUBMITTED_NOTIFICATION_CREATED("game.result.submitted.notification.created"),
 
+    // 게임 결과 거절 알림 생성
+    GAME_RESULT_REJECTED_NOTIFICATION_CREATED("game.result.rejected.notification.created"),
+
     // 리뷰 제출 알림 생성
     REVIEW_RECEIVED_NOTIFICATION_CREATED("review.received.notification.created"),
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
@@ -54,4 +54,30 @@ interface UserSportProfileRepository : JpaRepository<UserSportProfile, String> {
         userId: String,
         sportId: Long,
     ): UserSportProfile?
+
+    @Query(
+        """
+        select usp.id
+        from UserSportProfile usp
+        where usp.user.id = :userId
+          and usp.sport.id = :sportId
+        """
+    )
+    fun findProfileIdByUserIdAndSportId(
+        userId: String,
+        sportId: Long,
+    ): String?
+
+    @Query(
+        """
+        select usp.tier.id
+        from UserSportProfile usp
+        where usp.user.id = :userId
+          and usp.sport.id = :sportId
+        """
+    )
+    fun findTierIdByUserIdAndSportId(
+        userId: String,
+        sportId: Long,
+    ): Long?
 }

--- a/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
@@ -71,6 +71,7 @@ enum class ErrorCode(
     GAME_SUBMISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "GAME-013", "경기 결과 제출안을 찾을 수 없습니다."),
     GAME_SUBMISSION_NOT_SUBMITTED(HttpStatus.BAD_REQUEST, "GAME-014", "이미 처리된 제출안입니다."),
     GAME_SUBMISSION_CONFIRMER_MISMATCH(HttpStatus.FORBIDDEN, "GAME-015", "해당 제출안을 확정할 권한이 없습니다."),
+    GAME_RESULT_ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST, "GAME-016", "확정된 경기는 삭제할 수 없습니다."),
 
     // Domain - Tier
     TIER_NOT_FOUND(HttpStatus.NOT_FOUND, "TIER-001", "LP에 해당하는 티어 정보를 찾을 수 없습니다."),

--- a/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
@@ -77,5 +77,6 @@ enum class ErrorCode(
 
     // Domain - Notification
     NOTIFICATION_TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTI-001", "알림 템플릿을 찾을 수 없습니다."),
+    NOTIFICATION_RESULT_REJECTED_TYPE_MISMATCH(HttpStatus.INTERNAL_SERVER_ERROR, "NOTI-002", "결과 반려 알림 타입이 올바르지 않습니다."),
 
 }


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #29

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 경기 결과 제출안 거절 API, 경기 삭제 API를 구현합니다.
- 거절 성공 시, 제출자(상대)에게 다음이 함께 발생합니다.
  - Game 상태 변경: WAITING_CONFIRMATION → RESULT_REJECTED
  - Submission 상태 변경: SUBMITTED → REJECTED + actedAt, reason 저장
  - SSE 이벤트 전송
  - game.updated : 결과 상태 변경 전달 (resultStatus=RESULT_REJECTED)
  - game.result.rejected.notification.created : 결과 거절 알림 생성 이벤트 전달
  - Notification 생성 (거절 사유별로 타입 분리)

- 삭제 성공 시, 상대에게 다음이 함께 발생합니다.
  - Game 상태 변경: resultStatus = CANCELED
  - GameResultSubmission 전체 soft delete (deletedAt 세팅)
  - Game soft delete
  - SSE 이벤트 전송
  - game.updated : 상대에게 발행 (resultStatus=CANCELED)
 
- game.cancel()로 상태를 먼저 변경하고 flush()로 반영한 뒤, submission soft delete → game delete 순으로 처리해 “취소 상태 + 삭제” 흐름이 명확히 남도록 구성했습니다.
- Game unique constraint 를 추가해 matching_id 유니크를 의도적으로 1:1을 DB 레벨에서 보장하려 하였습니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 경기 결과 제출안 거절 API 구현
- [x] 경기 삭제 API 구현

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 경기 결과 제출안 거절 API
<img width="1050" height="570" alt="image" src="https://github.com/user-attachments/assets/c575ea2c-db2e-41d3-aa09-de173f3ea07b" />
<img width="1218" height="1028" alt="image" src="https://github.com/user-attachments/assets/244d443a-455f-4260-a38d-f6b6e9c8a854" />

- 경기 삭제 API
<img width="1026" height="852" alt="image" src="https://github.com/user-attachments/assets/e57084a8-1953-4b8d-a1f0-944624fa4cdb" />


## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 매칭 관련해서 이전에 놓쳤던 동시성 문제가 터질 수도 있는 부분들을 알아차려서 해당 부분들에 락을 추가하였습니다!