### PR TITLE
[FEAT] 사용자 프로필 추가 API 구현

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/domain/user/command/ProfileAddCommand.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/command/ProfileAddCommand.kt
@@ -1,0 +1,6 @@
+package org.appjam.smashing.domain.user.command
+
+data class ProfileAddCommand(
+    val sportCode: String,
+    val tier: String,
+)

--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -49,7 +49,7 @@ class UserController(
         )
     }
 
-    @PostMapping("me/profiles")
+    @PostMapping("/me/profiles")
     fun addProfile(
         @RequestHeader("userId") userId: String, // TODO: 인증/인가 회복시 @AuthenticationPrincipal 으로 변경
         @Valid @RequestBody profileAddRequest: ProfileAddRequest,

--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -56,7 +56,7 @@ class UserController(
     ): ResponseEntity<ApiResponse<Unit>> {
         userService.addProfile(
             userId = userId,
-            command = profileAddCommand
+            requestCommand = profileAddCommand
         )
 
         return ApiResponse.success()

--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -1,6 +1,7 @@
 package org.appjam.smashing.domain.user.controller
 
 import jakarta.validation.Valid
+import org.appjam.smashing.domain.user.command.ProfileAddCommand
 import org.appjam.smashing.domain.user.dto.request.OpenChatValidateRequest
 import org.appjam.smashing.domain.user.dto.response.NicknameCheckResponse
 import org.appjam.smashing.domain.user.dto.response.OpenChatValidateResponse
@@ -46,5 +47,18 @@ class UserController(
         return ApiResponse.success(
             data = response
         )
+    }
+
+    @PostMapping("me/profiles")
+    fun addProfile(
+        @RequestHeader("userId") userId: String, // TODO: 인증/인가 회복시 @AuthenticationPrincipal 으로 변경
+        @Valid profileAddCommand: ProfileAddCommand,
+    ): ResponseEntity<ApiResponse<Unit>> {
+        userService.addProfile(
+            userId = userId,
+            command = profileAddCommand
+        )
+
+        return ApiResponse.success()
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -1,8 +1,8 @@
 package org.appjam.smashing.domain.user.controller
 
 import jakarta.validation.Valid
-import org.appjam.smashing.domain.user.command.ProfileAddCommand
 import org.appjam.smashing.domain.user.dto.request.OpenChatValidateRequest
+import org.appjam.smashing.domain.user.dto.request.ProfileAddRequest
 import org.appjam.smashing.domain.user.dto.response.NicknameCheckResponse
 import org.appjam.smashing.domain.user.dto.response.OpenChatValidateResponse
 import org.appjam.smashing.domain.user.dto.response.UserProfileTierResponse
@@ -52,11 +52,11 @@ class UserController(
     @PostMapping("me/profiles")
     fun addProfile(
         @RequestHeader("userId") userId: String, // TODO: 인증/인가 회복시 @AuthenticationPrincipal 으로 변경
-        @Valid profileAddCommand: ProfileAddCommand,
+        @Valid @RequestBody profileAddRequest: ProfileAddRequest,
     ): ResponseEntity<ApiResponse<Unit>> {
         userService.addProfile(
             userId = userId,
-            requestCommand = profileAddCommand
+            requestCommand = profileAddRequest.toCommand()
         )
 
         return ApiResponse.success()

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/request/ProfileAddRequest.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/request/ProfileAddRequest.kt
@@ -1,0 +1,16 @@
+package org.appjam.smashing.domain.user.dto.request
+
+import jakarta.validation.constraints.NotBlank
+import org.appjam.smashing.domain.user.command.ProfileAddCommand
+
+data class ProfileAddRequest(
+    @field:NotBlank(message = "sportCode를 입력해주세요.")
+    val sportCode: String?,
+    @field:NotBlank(message = "tier를 입력해주세요.")
+    val tier: String?,
+) {
+    fun toCommand() = ProfileAddCommand(
+        sportCode = sportCode!!,
+        tier = tier!!,
+    )
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
@@ -94,4 +94,6 @@ interface UserSportProfileRepository : JpaRepository<UserSportProfile, String> {
     fun findAllByUserId(
         userId: String,
     ): List<UserSportProfile>
+
+    fun existsByUserIdAndSportId(userId: String, sportId: Long): Boolean
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -110,7 +110,8 @@ class UserService(
         userId: String,
         requestCommand: ProfileAddCommand,
     ) {
-        val user = userRepository.findById(userId).orElseThrow { CustomException(ErrorCode.USER_NOT_FOUND) }
+        val user = userRepository.findByIdOrNull(userId)
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
         val sport = sportRepository.findByCode(requestCommand.sportCode)
             ?: throw CustomException(ErrorCode.SPORT_NOT_FOUND)

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -114,6 +114,8 @@ class UserService(
         val sport = sportRepository.findByCode(requestCommand.sportCode)
             ?: throw CustomException(ErrorCode.SPORT_NOT_FOUND)
 
+        validateAlreadyRegisteredSport(user.id!!, sport.id!!)
+
         val tierName = requestCommand.tier
         val initTier = runCatching { InitTierLp.valueOf(tierName) }.getOrNull()
             ?: throw CustomException(ErrorCode.INVALID_INITIAL_TIER)
@@ -132,6 +134,12 @@ class UserService(
         )
 
         user.updateActiveProfile(profile.id!!)
+    }
+
+    private fun validateAlreadyRegisteredSport(userId: String, sportId: Long) {
+        if (userSportProfileRepository.existsByUserIdAndSportId(userId, sportId)) {
+            throw CustomException(ErrorCode.ALREADY_EXIST_SPORT_PROFILE)
+        }
     }
 
     companion object {

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -1,9 +1,14 @@
 package org.appjam.smashing.domain.user.service
 
+import org.appjam.smashing.domain.sport.enums.InitTierLp
+import org.appjam.smashing.domain.sport.repository.SportRepository
+import org.appjam.smashing.domain.tier.repository.TierRepository
 import org.appjam.smashing.domain.user.command.OpenChatValidateCommand
+import org.appjam.smashing.domain.user.command.ProfileAddCommand
 import org.appjam.smashing.domain.user.dto.response.NicknameCheckResponse
 import org.appjam.smashing.domain.user.dto.response.OpenChatValidateResponse
 import org.appjam.smashing.domain.user.dto.response.UserProfileTierResponse
+import org.appjam.smashing.domain.user.entity.UserSportProfile
 import org.appjam.smashing.domain.user.repository.UserRepository
 import org.appjam.smashing.domain.user.repository.UserSportProfileRepository
 import org.appjam.smashing.global.exception.CustomException
@@ -16,6 +21,8 @@ import org.springframework.transaction.annotation.Transactional
 class UserService(
     private val userRepository: UserRepository,
     private val userSportProfileRepository: UserSportProfileRepository,
+    private val sportRepository: SportRepository,
+    private val tierRepository: TierRepository,
 ) {
     @Transactional(readOnly = true)
     fun checkNicknameAvailability(
@@ -96,6 +103,35 @@ class UserService(
             ),
             sports = sportsList
         )
+    }
+
+    fun addProfile(
+        userId: String,
+        requestCommand: ProfileAddCommand,
+    ) {
+        val user = userRepository.findById(userId).orElseThrow { CustomException(ErrorCode.USER_NOT_FOUND) }
+
+        val sport = sportRepository.findByCode(requestCommand.sportCode)
+            ?: throw CustomException(ErrorCode.SPORT_NOT_FOUND)
+
+        val tierName = requestCommand.tier
+        val initTier = runCatching { InitTierLp.valueOf(tierName) }.getOrNull()
+            ?: throw CustomException(ErrorCode.INVALID_INITIAL_TIER)
+        val tier = tierRepository.findBySportIdAndName(
+            sportId = sport.id!!,
+            name = tierName,
+        ) ?: throw CustomException(ErrorCode.INVALID_TIER_SETTING)
+
+        val profile = userSportProfileRepository.save(
+            UserSportProfile.create(
+                lp = initTier.initLp,
+                user = user,
+                sport = sport,
+                tier = tier,
+            )
+        )
+
+        user.updateActiveProfile(profile.id!!)
     }
 
     companion object {

--- a/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
@@ -54,6 +54,7 @@ enum class ErrorCode(
     INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST, "USER-005", "특수문자는 사용할 수 없습니다."),
     DUPLICATE_OPEN_CHAT_URL(HttpStatus.CONFLICT, "USER-006", "이미 사용중인 오픈채팅방 링크입니다."),
     INVALID_OPENCHAT_FORMAT(HttpStatus.BAD_REQUEST, "USER-007", "잘못된 오픈채팅 링크 형식입니다."),
+    ALREADY_EXIST_SPORT_PROFILE(HttpStatus.CONFLICT, "USER-008", "이미 존재하는 스포츠 프로필입니다."),
 
     // Domain - Matching
     MATCHING_REQUESTER_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH-001", "요청자 유저를 찾을 수 없습니다."),


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #33

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 사용자 프로필 추가 API 구현
  - [회원가입](https://github.com/TEAM-SMASHING/SMASHING-SERVER/pull/27)에서 초기 스포츠 프로필과 티어를 설정하는 로직과 비슷합니다!
  - 흐름을 요약하면 아래와 같습니다.
  > 스포츠 조회 → `*추가`: 사용자에게 이미 존재하는 스포츠면 400오류 → 티어 조회 → 스포츠 프로필 추가

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 사용자 프로필 추가 API 구현

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 정상적으로 추가했을 때
<img width="496"  src="https://github.com/user-attachments/assets/73596b95-52d7-4d71-a6cd-deb6532b3fe4" />

- 이미 존재하는 스포츠 프로필을 추가하려고 했을 때
<img width="557" height="249" alt="image" src="https://github.com/user-attachments/assets/c68c37f8-6335-406c-bf06-dde78d62899a" />


## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 하나 고민이었던 부분은 join fetch를 사용해야 하나 였는데요..! 찾아보니 exist와 같은 존재여부 확인은 객체 그래프를 전부 메모리에 올리는 일이 오히려 불필요한 작업이 될 수 있어 지양해야 된다고 하더라구요 그래서 사용해주지 않았습니다!