### PR TITLE
[FEAT] 내 활성 프로필 전환 API 구현

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/domain/auth/dto/command/SignInRequestCommand.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/auth/dto/command/SignInRequestCommand.kt
@@ -1,4 +1,4 @@
-package org.appjam.smashing.domain.auth.command
+package org.appjam.smashing.domain.auth.dto.command
 
 data class SignInRequestCommand(
     val accessToken: String,

--- a/src/main/kotlin/org/appjam/smashing/domain/auth/dto/command/SignUpRequestCommand.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/auth/dto/command/SignUpRequestCommand.kt
@@ -1,4 +1,4 @@
-package org.appjam.smashing.domain.auth.command
+package org.appjam.smashing.domain.auth.dto.command
 
 import org.appjam.smashing.domain.user.enums.Gender
 

--- a/src/main/kotlin/org/appjam/smashing/domain/auth/dto/request/SignInRequest.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/auth/dto/request/SignInRequest.kt
@@ -1,7 +1,7 @@
 package org.appjam.smashing.domain.auth.dto.request
 
 import jakarta.validation.constraints.NotBlank
-import org.appjam.smashing.domain.auth.command.SignInRequestCommand
+import org.appjam.smashing.domain.auth.dto.command.SignInRequestCommand
 
 data class SignInRequest(
     @field:NotBlank(message = "엑세스 토큰을 입력해주세요.")

--- a/src/main/kotlin/org/appjam/smashing/domain/auth/dto/request/SignUpRequest.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/auth/dto/request/SignUpRequest.kt
@@ -1,7 +1,7 @@
 package org.appjam.smashing.domain.auth.dto.request
 
 import jakarta.validation.constraints.NotBlank
-import org.appjam.smashing.domain.auth.command.SignUpRequestCommand
+import org.appjam.smashing.domain.auth.dto.command.SignUpRequestCommand
 import org.appjam.smashing.domain.user.enums.Gender
 import org.appjam.smashing.global.common.validator.annotation.ValidEnum
 import org.appjam.smashing.global.extensions.ofIgnoreCase

--- a/src/main/kotlin/org/appjam/smashing/domain/auth/service/AuthService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/auth/service/AuthService.kt
@@ -1,7 +1,7 @@
 package org.appjam.smashing.domain.auth.service
 
-import org.appjam.smashing.domain.auth.command.SignInRequestCommand
-import org.appjam.smashing.domain.auth.command.SignUpRequestCommand
+import org.appjam.smashing.domain.auth.dto.command.SignInRequestCommand
+import org.appjam.smashing.domain.auth.dto.command.SignUpRequestCommand
 import org.appjam.smashing.domain.auth.dto.response.SignInResponse
 import org.appjam.smashing.domain.auth.dto.response.SignUpResponse
 import org.appjam.smashing.domain.auth.social.SocialAuthServiceManager

--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -107,4 +107,3 @@ class UserController(
         return ApiResponse.success()
     }
 }
-

--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -99,7 +99,10 @@ class UserController(
         @RequestHeader("userId") userId: String, // TODO: 인증/인가 회복시 @AuthenticationPrincipal 으로 변경
         @Valid @RequestBody activeProfileUpdateRequest: ActiveProfileUpdateRequest,
     ): ResponseEntity<ApiResponse<Unit>> {
-        userService.updateActiveProfile(activeProfileUpdateRequest.toCommand())
+        userService.updateActiveProfile(
+            userId = userId,
+            requestCommand = activeProfileUpdateRequest.toCommand()
+        )
 
         return ApiResponse.success()
     }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -1,6 +1,7 @@
 package org.appjam.smashing.domain.user.controller
 
 import jakarta.validation.Valid
+import org.appjam.smashing.domain.user.dto.request.ActiveProfileUpdateRequest
 import org.appjam.smashing.domain.user.dto.request.AddressUpdateRequest
 import org.appjam.smashing.domain.user.dto.request.OpenChatValidateRequest
 import org.appjam.smashing.domain.user.dto.request.ProfileAddRequest
@@ -96,8 +97,10 @@ class UserController(
     @PutMapping("/me/active-profile")
     fun updateActiveProfile(
         @RequestHeader("userId") userId: String, // TODO: 인증/인가 회복시 @AuthenticationPrincipal 으로 변경
+        @Valid @RequestBody activeProfileUpdateRequest: ActiveProfileUpdateRequest,
+    ): ResponseEntity<ApiResponse<Unit>> {
+        userService.updateActiveProfile(activeProfileUpdateRequest.toCommand())
 
-    ) {
-
+        return ApiResponse.success()
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -92,4 +92,9 @@ class UserController(
 
         return ApiResponse.success()
     }
+
+    @PutMapping("/me/active-profile")
+    fun updateActiveProfile() {
+        
+    }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -94,7 +94,10 @@ class UserController(
     }
 
     @PutMapping("/me/active-profile")
-    fun updateActiveProfile() {
-        
+    fun updateActiveProfile(
+        @RequestHeader("userId") userId: String, // TODO: 인증/인가 회복시 @AuthenticationPrincipal 으로 변경
+
+    ) {
+
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/command/ActiveProfileUpdateCommand.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/command/ActiveProfileUpdateCommand.kt
@@ -1,0 +1,5 @@
+package org.appjam.smashing.domain.user.dto.command
+
+data class ActiveProfileUpdateCommand(
+    val profileId: String,
+)

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/request/ActiveProfileUpdateRequest.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/request/ActiveProfileUpdateRequest.kt
@@ -1,0 +1,11 @@
+package org.appjam.smashing.domain.user.dto.request
+
+import org.appjam.smashing.domain.user.dto.command.ActiveProfileUpdateCommand
+
+data class ActiveProfileUpdateRequest(
+    val profileId: String,
+) {
+    fun toCommand() = ActiveProfileUpdateCommand(
+        profileId = profileId,
+    )
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -19,7 +19,6 @@ import org.appjam.smashing.global.exception.ErrorCode
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.reactive.TransactionalOperator
 
 @Service
 @Transactional
@@ -28,7 +27,6 @@ class UserService(
     private val userSportProfileRepository: UserSportProfileRepository,
     private val sportRepository: SportRepository,
     private val tierRepository: TierRepository,
-    private val transactionalOperator: TransactionalOperator,
 ) {
     @Transactional(readOnly = true)
     fun checkNicknameAvailability(
@@ -190,6 +188,10 @@ class UserService(
     ) {
         val user = userRepository.findByIdOrNull(userId)
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+
+        if (!userSportProfileRepository.existsById(requestCommand.profileId)) {
+            throw CustomException(ErrorCode.USER_SPORT_PROFILE_NOT_FOUND)
+        }
 
         user.updateActiveProfile(requestCommand.profileId)
     }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -3,6 +3,7 @@ package org.appjam.smashing.domain.user.service
 import org.appjam.smashing.domain.sport.enums.InitTierLp
 import org.appjam.smashing.domain.sport.repository.SportRepository
 import org.appjam.smashing.domain.tier.repository.TierRepository
+import org.appjam.smashing.domain.user.dto.command.ActiveProfileUpdateCommand
 import org.appjam.smashing.domain.user.dto.command.AddressUpdateCommand
 import org.appjam.smashing.domain.user.dto.command.OpenChatValidateCommand
 import org.appjam.smashing.domain.user.dto.command.ProfileAddCommand
@@ -18,6 +19,7 @@ import org.appjam.smashing.global.exception.ErrorCode
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.reactive.TransactionalOperator
 
 @Service
 @Transactional
@@ -26,6 +28,7 @@ class UserService(
     private val userSportProfileRepository: UserSportProfileRepository,
     private val sportRepository: SportRepository,
     private val tierRepository: TierRepository,
+    private val transactionalOperator: TransactionalOperator,
 ) {
     @Transactional(readOnly = true)
     fun checkNicknameAvailability(
@@ -179,6 +182,16 @@ class UserService(
         // TODO: 지역 관련 검증 로직 추가 필요
 
         user.updateRegion(requestCommand.region)
+    }
+
+    fun updateActiveProfile(
+        userId: String,
+        requestCommand: ActiveProfileUpdateCommand,
+    ) {
+        val user = userRepository.findByIdOrNull(userId)
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+
+        user.updateActiveProfile(requestCommand.profileId)
     }
 
     companion object {

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -185,6 +185,7 @@ class UserService(
         user.updateRegion(requestCommand.region)
     }
 
+    @Transactional
     fun updateActiveProfile(
         userId: String,
         requestCommand: ActiveProfileUpdateCommand,


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #36

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 내 활성 프로필 전환 API 구현했습니다.
- auth 로직도 command 파일을 dto 하위에 두었습니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 내 활성 프로필 전환 API 구현

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 200 Ok
<img width="661"  src="https://github.com/user-attachments/assets/051fc593-80f6-4070-a735-cca54ae3521e" />


## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 내용