### PR TITLE
[FEAT] 내 알림 목록 조회 API, 내가 받은 매칭 요청 목록 조회 API, 내가 보낸 매칭 요청 목록 조회 API, 결과 확정 전 수락된 경기 목록 조회 API 작성

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/domain/game/controller/MyGameController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/controller/MyGameController.kt
@@ -16,8 +16,8 @@ import org.springframework.web.bind.annotation.RestController
 
 @Tag(name = "Game")
 @RestController
-@RequestMapping("/api/v1/games")
-class GameQueryController(
+@RequestMapping("/api/v1/users/me/games")
+class MyGameController(
     private val gameService: GameService,
 ) {
 
@@ -44,7 +44,7 @@ class GameQueryController(
               - 잠금 시간 계산만 '오늘 기준 정책'으로 계산해 내려줌
         """
     )
-    @GetMapping("/accepted/pending-result")
+    @GetMapping("/pending-results")
     fun getPendingResultAcceptedGames(
         @RequestHeader("userId") userId: String, // TODO: 인증/인가 적용 시 변경
         @Valid request: CommonCursorRequest,

--- a/src/main/kotlin/org/appjam/smashing/domain/game/controller/MyGameController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/controller/MyGameController.kt
@@ -1,0 +1,59 @@
+package org.appjam.smashing.domain.game.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.appjam.smashing.domain.game.dto.response.PendingResultAcceptedGameSummaryResponse
+import org.appjam.smashing.domain.game.service.GameService
+import org.appjam.smashing.global.common.dto.ApiResponse
+import org.appjam.smashing.global.common.dto.CommonCursorRequest
+import org.appjam.smashing.global.common.dto.CursorResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "Game")
+@RestController
+@RequestMapping("/api/v1/games")
+class GameQueryController(
+    private val gameService: GameService,
+) {
+
+    @Operation(
+        summary = "결과 확정 전(수락된) 게임 목록 조회 API",
+        description = """
+            매칭 수락(ACCEPTED)되어 게임이 자동 생성된 이후, 아직 결과가 확정(RESULT_CONFIRMED)되지 않은 게임 목록을 조회합니다.
+
+            - 조회 대상(resultStatus):
+              - PENDING_RESULT / WAITING_CONFIRMATION / RESULT_REJECTED (CONFIRMED, CANCELED 제외)
+
+            - 기준 스포츠:
+              - 로그인 유저의 활성 프로필(activeUserSportProfileId)의 sport
+
+            - 정렬:
+              - gameId(TSID) DESC
+
+            - 페이징:
+              - snapshotAt 이전 데이터만 조회(스냅샷 고정)
+              - cursor = gameId (마지막 gameId)
+
+            - 잠금(결과 제출 가능 시각) 계산:
+              - 목록은 전체(스냅샷 이전) 조회
+              - 잠금 시간 계산만 '오늘 기준 정책'으로 계산해 내려줌
+        """
+    )
+    @GetMapping("/accepted/pending-result")
+    fun getPendingResultAcceptedGames(
+        @RequestHeader("userId") userId: String, // TODO: 인증/인가 적용 시 변경
+        @Valid request: CommonCursorRequest,
+    ): ResponseEntity<ApiResponse<CursorResponse<PendingResultAcceptedGameSummaryResponse>>> {
+        val response = gameService.getPendingResultAcceptedGames(
+            userId = userId,
+            request = request,
+        )
+
+        return ApiResponse.success(response)
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/game/dto/projection/PendingResultAcceptedGameProjection.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/dto/projection/PendingResultAcceptedGameProjection.kt
@@ -1,0 +1,31 @@
+package org.appjam.smashing.domain.game.dto.projection
+
+import com.querydsl.core.annotations.QueryProjection
+import org.appjam.smashing.domain.game.enums.GameResultStatus
+import org.appjam.smashing.domain.user.enums.Gender
+import org.appjam.smashing.global.common.dto.CursorKey
+import org.appjam.smashing.global.util.TimeUtils
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+
+@QueryProjection
+data class PendingResultAcceptedGameProjection(
+    val gameId: String,
+    val createdAtLdt: LocalDateTime,
+    val resultStatus: GameResultStatus,
+    val requesterUserId: String,
+    val receiverUserId: String,
+    val opponentUserId: String,
+    val opponentNickname: String,
+    val opponentOpenchatUrl: String?,
+    val opponentGender: Gender,
+    val opponentTierId: Long,
+    val opponentTierName: String,
+) : CursorKey {
+
+    override val cursorId: String
+        get() = gameId
+
+    val createdAt: OffsetDateTime
+        get() = TimeUtils.toOffsetDateTime(createdAtLdt)
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/game/dto/response/GameResultSubmitLockResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/dto/response/GameResultSubmitLockResponse.kt
@@ -1,0 +1,28 @@
+package org.appjam.smashing.domain.game.dto.response
+
+import org.appjam.smashing.global.util.TimeUtils
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.temporal.ChronoUnit
+
+data class GameResultSubmitLockResponse(
+    val submitAvailableAt: OffsetDateTime,
+    val remainingSeconds: Long,
+    val isLocked: Boolean,
+) {
+    companion object {
+        fun from(
+            now: LocalDateTime,
+            availableAt: LocalDateTime,
+        ): GameResultSubmitLockResponse {
+            val locked = now.isBefore(availableAt)
+            val remainingSeconds = if (locked) ChronoUnit.SECONDS.between(now, availableAt) else 0L
+
+            return GameResultSubmitLockResponse(
+                submitAvailableAt = TimeUtils.toOffsetDateTime(availableAt),
+                remainingSeconds = remainingSeconds,
+                isLocked = locked,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/game/dto/response/PendingResultAcceptedGameSummaryResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/dto/response/PendingResultAcceptedGameSummaryResponse.kt
@@ -1,0 +1,50 @@
+package org.appjam.smashing.domain.game.dto.response
+
+import org.appjam.smashing.domain.game.dto.projection.PendingResultAcceptedGameProjection
+import org.appjam.smashing.domain.game.enums.GameResultStatus
+import org.appjam.smashing.domain.user.enums.Gender
+import java.time.OffsetDateTime
+
+data class PendingResultAcceptedGameSummaryResponse(
+    val gameId: String,
+    val createdAt: OffsetDateTime,
+    val resultStatus: GameResultStatus,
+    val opponent: OpponentSummary,
+    val submitAvailableAt: OffsetDateTime,
+    val remainingSeconds: Long,
+    val isSubmitLocked: Boolean,
+) {
+
+    data class OpponentSummary(
+        val userId: String,
+        val nickname: String,
+        val openchatUrl: String?,
+        val gender: Gender,
+        val tierId: Long,
+        val tierName: String,
+    )
+
+    companion object {
+        fun from(
+            projection: PendingResultAcceptedGameProjection,
+            submitAvailableAt: OffsetDateTime,
+            remainingSeconds: Long,
+            isSubmitLocked: Boolean,
+        ) = PendingResultAcceptedGameSummaryResponse(
+            gameId = projection.gameId,
+            createdAt = projection.createdAt,
+            resultStatus = projection.resultStatus,
+            opponent = OpponentSummary(
+                userId = projection.opponentUserId,
+                nickname = projection.opponentNickname,
+                openchatUrl = projection.opponentOpenchatUrl,
+                gender = projection.opponentGender,
+                tierId = projection.opponentTierId,
+                tierName = projection.opponentTierName,
+            ),
+            submitAvailableAt = submitAvailableAt,
+            remainingSeconds = remainingSeconds,
+            isSubmitLocked = isSubmitLocked,
+        )
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepository.kt
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.LocalDateTime
 
-interface GameRepository : JpaRepository<Game, String> {
+interface GameRepository : JpaRepository<Game, String>, GameRepositoryCustom {
     fun existsByMatchingId(
         matchingId: String
     ): Boolean

--- a/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepositoryCustom.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepositoryCustom.kt
@@ -1,0 +1,16 @@
+package org.appjam.smashing.domain.game.repository
+
+import org.appjam.smashing.domain.game.dto.projection.PendingResultAcceptedGameProjection
+import org.appjam.smashing.global.common.dto.CommonCursorRequest
+import org.appjam.smashing.global.common.dto.CursorPageResponse
+import java.time.OffsetDateTime
+
+interface GameRepositoryCustom {
+
+    fun fetchPendingResultAcceptedGamesPage(
+        userId: String,
+        sportId: Long,
+        request: CommonCursorRequest,
+        snapshotAt: OffsetDateTime,
+    ): CursorPageResponse<PendingResultAcceptedGameProjection>
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepositoryCustomImpl.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepositoryCustomImpl.kt
@@ -1,0 +1,129 @@
+package org.appjam.smashing.domain.game.repository
+
+import com.querydsl.core.BooleanBuilder
+import com.querydsl.core.types.dsl.CaseBuilder
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.appjam.smashing.domain.game.dto.projection.PendingResultAcceptedGameProjection
+import org.appjam.smashing.domain.game.dto.projection.QPendingResultAcceptedGameProjection
+import org.appjam.smashing.domain.game.entity.QGame.Companion.game
+import org.appjam.smashing.domain.game.enums.GameResultStatus
+import org.appjam.smashing.domain.matching.entity.QMatching.Companion.matching
+import org.appjam.smashing.domain.matching.enums.MatchingStatus
+import org.appjam.smashing.domain.tier.entity.QTier
+import org.appjam.smashing.domain.user.entity.QUser
+import org.appjam.smashing.domain.user.entity.QUserSportProfile
+import org.appjam.smashing.global.common.dto.CommonCursorRequest
+import org.appjam.smashing.global.common.dto.CursorPageResponse
+import org.appjam.smashing.global.util.CursorCodec
+import org.appjam.smashing.global.util.TimeUtils
+import org.springframework.stereotype.Repository
+import java.time.OffsetDateTime
+
+@Repository
+class GameRepositoryCustomImpl(
+    private val queryFactory: JPAQueryFactory,
+    private val cursorCodec: CursorCodec,
+) : GameRepositoryCustom {
+
+    override fun fetchPendingResultAcceptedGamesPage(
+        userId: String,
+        sportId: Long,
+        request: CommonCursorRequest,
+        snapshotAt: OffsetDateTime,
+    ): CursorPageResponse<PendingResultAcceptedGameProjection> {
+
+        val size = request.size.coerceIn(1, 50).toInt()
+        val cursor = cursorCodec.decode(request.cursor)
+
+        val snapshotLocal = snapshotAt
+            .atZoneSameInstant(TimeUtils.DEFAULT_ZONE_ID)
+            .toLocalDateTime()
+
+        val requester = QUser("requester")
+        val receiver = QUser("receiver")
+        val requesterProfile = QUserSportProfile("requesterProfile")
+        val receiverProfile = QUserSportProfile("receiverProfile")
+        val requesterTier = QTier("requesterTier")
+        val receiverTier = QTier("receiverTier")
+
+        val opponentIdExpr = CaseBuilder().`when`(matching.requester.id.eq(userId)).then(receiver.id)
+            .otherwise(requester.id)
+
+        val opponentNicknameExpr = CaseBuilder().`when`(matching.requester.id.eq(userId)).then(receiver.nickname)
+            .otherwise(requester.nickname)
+
+        val opponentOpenchatExpr = CaseBuilder().`when`(matching.requester.id.eq(userId)).then(receiver.openchatUrl)
+            .otherwise(requester.openchatUrl)
+
+        val opponentGenderExpr = CaseBuilder().`when`(matching.requester.id.eq(userId)).then(receiver.gender)
+            .otherwise(requester.gender)
+
+        val opponentTierIdExpr = CaseBuilder().`when`(matching.requester.id.eq(userId)).then(receiverTier.id)
+            .otherwise(requesterTier.id)
+
+        val opponentTierNameExpr = CaseBuilder().`when`(matching.requester.id.eq(userId)).then(receiverTier.name)
+            .otherwise(requesterTier.name)
+
+        val where = BooleanBuilder().and(
+                matching.requester.id.eq(userId)
+                    .or(matching.receiver.id.eq(userId))
+            )
+            .and(matching.sport.id.eq(sportId))
+            .and(matching.status.eq(MatchingStatus.ACCEPTED))
+            .and(game.createdAt.loe(snapshotLocal))
+            .and(
+                game.resultStatus.`in`(
+                    GameResultStatus.PENDING_RESULT,
+                    GameResultStatus.WAITING_CONFIRMATION,
+                    GameResultStatus.RESULT_REJECTED,
+                )
+            )
+
+        if (cursor != null) {
+            where.and(game.id.lt(cursor.id))
+        }
+
+        val projections = queryFactory
+            .select(
+                QPendingResultAcceptedGameProjection(
+                    game.id,
+                    game.createdAt,
+                    game.resultStatus,
+                    matching.requester.id,
+                    matching.receiver.id,
+                    opponentIdExpr,
+                    opponentNicknameExpr,
+                    opponentOpenchatExpr,
+                    opponentGenderExpr,
+                    opponentTierIdExpr,
+                    opponentTierNameExpr,
+                )
+            )
+            .from(game)
+            .join(game.matching, matching)
+            .join(matching.requester, requester)
+            .join(matching.receiver, receiver)
+            .join(requesterProfile).on(
+                requesterProfile.user.eq(requester)
+                    .and(requesterProfile.sport.id.eq(sportId))
+            )
+            .join(requesterProfile.tier, requesterTier)
+            .join(receiverProfile).on(
+                receiverProfile.user.eq(receiver)
+                    .and(receiverProfile.sport.id.eq(sportId))
+            )
+            .join(receiverProfile.tier, receiverTier)
+
+            .where(where)
+            .orderBy(game.id.desc())
+            .limit((size + 1).toLong())
+            .fetch()
+
+        return CursorPageResponse.create(
+            snapshotAt = snapshotAt,
+            fetched = projections,
+            pageSize = size,
+            cursorCodec = cursorCodec,
+        )
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepositoryCustomImpl.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepositoryCustomImpl.kt
@@ -16,10 +16,8 @@ import org.appjam.smashing.global.common.dto.CommonCursorRequest
 import org.appjam.smashing.global.common.dto.CursorPageResponse
 import org.appjam.smashing.global.util.CursorCodec
 import org.appjam.smashing.global.util.TimeUtils
-import org.springframework.stereotype.Repository
 import java.time.OffsetDateTime
 
-@Repository
 class GameRepositoryCustomImpl(
     private val queryFactory: JPAQueryFactory,
     private val cursorCodec: CursorCodec,

--- a/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
@@ -128,10 +128,10 @@ class GameService(
         // 결과 제출 알림 + SSE 발행
         notifyGameResultSubmitted(
             receiver = confirmer,
+            receiverProfile = confirmerProfile,
             game = game,
             submission = submission,
             submitter = submitter,
-            receiverProfileId = confirmerProfile.id!!,
             submitterTierId = submitterProfile.tier.id!!,
         )
 
@@ -141,8 +141,8 @@ class GameService(
                 game = game,
                 reviewer = submitter,
                 reviewee = confirmer,
+                receiverProfile = confirmerProfile,
                 review = command.review!!,
-                receiverProfileId = confirmerProfile.id!!,
                 reviewerTierId = submitterProfile.tier.id!!,
             )
         }
@@ -230,8 +230,8 @@ class GameService(
                 game = game,
                 reviewer = submission.confirmer,
                 reviewee = submission.submitter,
+                receiverProfile = submitterProfile,
                 review = command.review!!,
-                receiverProfileId = submitterProfile.id!!,
                 reviewerTierId = confirmerProfile.tier.id!!,
             )
         }
@@ -306,13 +306,24 @@ class GameService(
             resultStatus = game.resultStatus,
         )
 
+        val receiverProfile = userSportProfileRepository.findByUserIdAndSportIdFetch(
+            userId = submission.submitter.id!!,
+            sportId = sportId,
+        ) ?: throw CustomException(ErrorCode.USER_SPORT_PROFILE_NOT_FOUND)
+
+        val rejectorProfile = userSportProfileRepository.findByUserIdAndSportIdFetch(
+            userId = submission.confirmer.id!!,
+            sportId = sportId,
+        ) ?: throw CustomException(ErrorCode.USER_SPORT_PROFILE_NOT_FOUND)
+
         // 결과 거절 알림 + SSE 발행
         notifyGameResultRejected(
             receiver = submission.submitter,
+            receiverProfile = receiverProfile,
             rejector = submission.confirmer,
+            rejectorTierId = rejectorProfile.tier.id!!,
             gameId = game.id!!,
             submissionId = submission.id!!,
-            sportId = sportId,
             reason = command.reason,
         )
     }
@@ -497,14 +508,15 @@ class GameService(
 
     private fun notifyGameResultSubmitted(
         receiver: User,
+        receiverProfile: UserSportProfile,
         game: Game,
         submission: GameResultSubmission,
         submitter: User,
-        receiverProfileId: String,
         submitterTierId: Long,
     ) {
         val notification = notificationService.createMatchingResultSubmitted(
             receiver = receiver,
+            receiverProfile = receiverProfile,
             gameId = game.id!!,
             submissionId = submission.id!!,
             submitterNickname = submitter.nickname,
@@ -524,7 +536,7 @@ class GameService(
                 notificationType = NotificationType.MATCHING_RESULT_SUBMITTED,
                 notificationCreatedAt = notificationCreatedAt,
                 sportId = game.sport.id!!,
-                receiverProfileId = receiverProfileId,
+                receiverProfileId = receiverProfile.id!!,
                 gameId = game.id!!,
                 submissionId = submission.id!!,
                 submitter = GameResultSubmittedNotificationCreatedPayload.SubmitterSummary(
@@ -540,8 +552,8 @@ class GameService(
         game: Game,
         reviewer: User,
         reviewee: User,
+        receiverProfile: UserSportProfile,
         review: GameResultSubmitCommand.ReviewCommand,
-        receiverProfileId: String,
         reviewerTierId: Long,
     ) {
         val savedReview = gameReviewService.createReview(
@@ -555,6 +567,7 @@ class GameService(
 
         val notification = notificationService.createReviewReceived(
             receiver = reviewee,
+            receiverProfile = receiverProfile,
             reviewId = savedReview.id!!,
             reviewerNickname = reviewer.nickname,
             reviewerTierId = reviewerTierId,
@@ -574,7 +587,7 @@ class GameService(
                 notificationType = NotificationType.REVIEW_RECEIVED,
                 notificationCreatedAt = notificationCreatedAt,
                 sportId = game.sport.id!!,
-                receiverProfileId = receiverProfileId,
+                receiverProfileId = receiverProfile.id!!,
                 gameId = game.id!!,
                 reviewId = savedReview.id!!,
                 reviewer = ReviewReceivedNotificationCreatedPayload.ReviewerSummary(
@@ -590,8 +603,8 @@ class GameService(
         game: Game,
         reviewer: User,
         reviewee: User,
+        receiverProfile: UserSportProfile,
         review: GameResultConfirmCommand.ReviewCommand,
-        receiverProfileId: String,
         reviewerTierId: Long,
     ) {
         val savedReview = gameReviewService.createReview(
@@ -605,6 +618,7 @@ class GameService(
 
         val notification = notificationService.createReviewReceived(
             receiver = reviewee,
+            receiverProfile = receiverProfile,
             reviewId = savedReview.id!!,
             reviewerNickname = reviewer.nickname,
             reviewerTierId = reviewerTierId,
@@ -624,7 +638,7 @@ class GameService(
                 notificationType = NotificationType.REVIEW_RECEIVED,
                 notificationCreatedAt = notificationCreatedAt,
                 sportId = game.sport.id!!,
-                receiverProfileId = receiverProfileId,
+                receiverProfileId = receiverProfile.id!!,
                 gameId = game.id!!,
                 reviewId = savedReview.id!!,
                 reviewer = ReviewReceivedNotificationCreatedPayload.ReviewerSummary(
@@ -653,22 +667,13 @@ class GameService(
 
     private fun notifyGameResultRejected(
         receiver: User,
+        receiverProfile: UserSportProfile,
         rejector: User,
+        rejectorTierId: Long,
         gameId: String,
         submissionId: String,
-        sportId: Long,
         reason: GameResultRejectReason,
     ) {
-        val receiverProfileId = userSportProfileRepository.findProfileIdByUserIdAndSportId(
-            userId = receiver.id!!,
-            sportId = sportId,
-        ) ?: throw CustomException(ErrorCode.USER_SPORT_PROFILE_NOT_FOUND)
-
-        val rejectorTierId = userSportProfileRepository.findTierIdByUserIdAndSportId(
-            userId = rejector.id!!,
-            sportId = sportId,
-        ) ?: throw CustomException(ErrorCode.USER_SPORT_PROFILE_NOT_FOUND)
-
         val notificationType = when (reason) {
             GameResultRejectReason.SCORE_MISMATCH -> NotificationType.RESULT_REJECTED_SCORE_MISMATCH
             GameResultRejectReason.WIN_LOSE_REVERSED -> NotificationType.RESULT_REJECTED_WIN_LOSE_REVERSED
@@ -676,6 +681,7 @@ class GameService(
 
         val notification = notificationService.createResultRejected(
             receiver = receiver,
+            receiverProfile = receiverProfile,
             notificationType = notificationType,
             gameId = gameId,
             submissionId = submissionId,
@@ -695,8 +701,8 @@ class GameService(
                 notificationId = notification.id!!,
                 notificationType = notificationType,
                 notificationCreatedAt = notificationCreatedAt,
-                sportId = sportId,
-                receiverProfileId = receiverProfileId,
+                sportId = receiverProfile.sport.id!!,
+                receiverProfileId = receiverProfile.id!!,
                 gameId = gameId,
                 submissionId = submissionId,
                 reason = reason,

--- a/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
@@ -4,6 +4,8 @@ import org.appjam.smashing.domain.game.dto.command.GameResultConfirmCommand
 import org.appjam.smashing.domain.game.dto.command.GameResultRejectCommand
 import org.appjam.smashing.domain.game.dto.command.GameResultSubmitCommand
 import org.appjam.smashing.domain.game.dto.response.GameResultSubmissionDetailResponse
+import org.appjam.smashing.domain.game.dto.response.GameResultSubmitLockResponse
+import org.appjam.smashing.domain.game.dto.response.PendingResultAcceptedGameSummaryResponse
 import org.appjam.smashing.domain.game.entity.Game
 import org.appjam.smashing.domain.game.entity.GameResultSubmission
 import org.appjam.smashing.domain.game.enums.GameResultRejectReason
@@ -24,9 +26,14 @@ import org.appjam.smashing.domain.tier.entity.Tier
 import org.appjam.smashing.domain.tier.repository.TierRepository
 import org.appjam.smashing.domain.user.entity.User
 import org.appjam.smashing.domain.user.entity.UserSportProfile
+import org.appjam.smashing.domain.user.repository.UserRepository
 import org.appjam.smashing.domain.user.repository.UserSportProfileRepository
+import org.appjam.smashing.global.common.dto.CommonCursorRequest
+import org.appjam.smashing.global.common.dto.CursorResponse
 import org.appjam.smashing.global.exception.CustomException
 import org.appjam.smashing.global.exception.ErrorCode
+import org.appjam.smashing.global.util.TimeUtils
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
@@ -36,6 +43,7 @@ import java.time.temporal.ChronoUnit
 @Service
 class GameService(
     private val gameRepository: GameRepository,
+    private val userRepository: UserRepository,
     private val submissionRepository: GameResultSubmissionRepository,
     private val notificationService: NotificationService,
     private val outboxEventPublisher: OutboxEventPublisher,
@@ -363,6 +371,106 @@ class GameService(
             gameId = game.id!!,
             resultStatus = game.resultStatus,
         )
+    }
+
+    @Transactional(readOnly = true)
+    fun getPendingResultAcceptedGames(
+        userId: String,
+        request: CommonCursorRequest,
+    ): CursorResponse<PendingResultAcceptedGameSummaryResponse> {
+        val user = userRepository.findByIdOrNull(userId)
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+
+        val activeProfileId = user.activeUserSportProfileId
+            ?: throw CustomException(ErrorCode.USER_SPORT_PROFILE_NOT_FOUND)
+
+        val activeProfile = userSportProfileRepository.findByIdOrNull(activeProfileId)
+            ?: throw CustomException(ErrorCode.USER_SPORT_PROFILE_NOT_FOUND)
+
+        val sportId = activeProfile.sport.id
+            ?: throw CustomException(ErrorCode.SPORT_NOT_FOUND)
+
+        val snapshotAt = request.snapshotAt ?: TimeUtils.nowOffsetDateTime()
+
+        val response = gameRepository.fetchPendingResultAcceptedGamesPage(
+            userId = userId,
+            sportId = sportId,
+            request = request,
+            snapshotAt = snapshotAt,
+        )
+
+        val now = LocalDateTime.now(TimeUtils.DEFAULT_ZONE_ID)
+        val startOfDay = now.toLocalDate().atStartOfDay()
+
+        val results = response.results.map { projection ->
+            val availableAt = calcSubmitAvailableAt(
+                now = now,
+                startOfDay = startOfDay,
+                gameCreatedAt = projection.createdAtLdt,
+                requesterId = projection.requesterUserId,
+                receiverId = projection.receiverUserId,
+            )
+
+            val lockResponse = GameResultSubmitLockResponse.from(
+                now = now,
+                availableAt = availableAt,
+            )
+
+            PendingResultAcceptedGameSummaryResponse.from(
+                projection = projection,
+                submitAvailableAt = lockResponse.submitAvailableAt,
+                remainingSeconds = lockResponse.remainingSeconds,
+                isSubmitLocked = lockResponse.isLocked,
+            )
+        }
+
+        return CursorResponse(
+            snapshotAt = response.snapshotAt,
+            results = results,
+            nextCursor = response.nextCursor,
+            hasNext = response.hasNext,
+        )
+    }
+
+    /**
+     * 오늘 기준(00:00~)
+     * - 오늘 확정 0건이면(= 오늘 첫 확정 후보): 생성 후 1시간 제출 불가
+     * - 오늘 확정 1~2건이면(= 오늘 2~3번째 확정 후보):
+     *   직전 확정이 30분 이내에 있었던 연속 확정 상황일 때만 생성 후 10분 제출 불가
+     */
+    private fun calcSubmitAvailableAt(
+        now: LocalDateTime,
+        startOfDay: LocalDateTime,
+        gameCreatedAt: LocalDateTime,
+        requesterId: String,
+        receiverId: String,
+    ): LocalDateTime {
+
+        val todayConfirmedCount = gameRepository.countTodayConfirmedGamesBetweenUsers(
+            startAt = startOfDay,
+            userA = requesterId,
+            userB = receiverId,
+        )
+
+        // 오늘 첫 확정 후보 → 생성 후 1시간 제한
+        if (todayConfirmedCount == 0L) {
+            return gameCreatedAt.plusHours(1)
+        }
+
+        // 오늘 2~3번째 확정 후보 → 연속 확정일 때만 10분 제한
+        if (todayConfirmedCount in 1L..2L) {
+            val prevConfirmedAt = gameRepository.findTodayLatestConfirmedAtBetweenUsers(
+                startAt = startOfDay,
+                userA = requesterId,
+                userB = receiverId,
+            ) ?: return gameCreatedAt
+
+            if (ChronoUnit.MINUTES.between(prevConfirmedAt, now) <= 30) {
+                return gameCreatedAt.plusMinutes(10)
+            }
+        }
+
+        return gameCreatedAt
     }
 
     private fun validateDeletable(

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/controller/MyMatchingController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/controller/MyMatchingController.kt
@@ -1,0 +1,48 @@
+package org.appjam.smashing.domain.matching.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.appjam.smashing.domain.matching.service.MatchingService
+import org.appjam.smashing.domain.matching.dto.response.ReceivedMatchingSummaryResponse
+import org.appjam.smashing.global.common.dto.CommonCursorRequest
+import org.appjam.smashing.global.common.dto.CursorResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "Matching")
+@RestController
+@RequestMapping("/api/v1/users/me/matchings")
+class MyMatchingController(
+    private val matchingService: MatchingService,
+) {
+
+    @Operation(
+        summary = "내가 받은 매칭 요청 목록 조회 API",
+        description = """
+            내가 받은 매칭 요청(REQUESTED 상태) 목록을 조회합니다.
+
+            - 정렬 기준
+             - 최신순: matching.id DESC (TSID 기반 최신순)
+            - 페이징 방식
+             - cursor(keyset) 기반 페이징
+             - nextCursor는 "마지막 matching id"로 생성.
+             - 다음 페이지 요청 시 cursor에 nextCursor를 전달.
+            - 스냅샷 고정
+             - 최초 요청에서 snapshotAt이 없으면 서버가 now로 고정.
+             - 다음 페이지 요청부터는 응답의 snapshotAt을 그대로 재전송.
+        """
+    )
+    @GetMapping("/received")
+    fun getReceivedMatchings(
+        @RequestHeader("userId") userId: String, // TODO: 인증/인가 적용 시 변경
+        @Valid request: CommonCursorRequest,
+    ): CursorResponse<ReceivedMatchingSummaryResponse> {
+        return matchingService.getReceivedMatchings(
+            userId = userId,
+            request = request,
+        )
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/controller/MyMatchingController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/controller/MyMatchingController.kt
@@ -6,8 +6,10 @@ import jakarta.validation.Valid
 import org.appjam.smashing.domain.matching.service.MatchingService
 import org.appjam.smashing.domain.matching.dto.response.ReceivedMatchingSummaryResponse
 import org.appjam.smashing.domain.matching.dto.response.SentMatchingSummaryResponse
+import org.appjam.smashing.global.common.dto.ApiResponse
 import org.appjam.smashing.global.common.dto.CommonCursorRequest
 import org.appjam.smashing.global.common.dto.CursorResponse
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
@@ -40,11 +42,13 @@ class MyMatchingController(
     fun getReceivedMatchings(
         @RequestHeader("userId") userId: String, // TODO: 인증/인가 적용 시 변경
         @Valid request: CommonCursorRequest,
-    ): CursorResponse<ReceivedMatchingSummaryResponse> {
-        return matchingService.getReceivedMatchings(
+    ): ResponseEntity<ApiResponse<CursorResponse<ReceivedMatchingSummaryResponse>>> {
+        val response = matchingService.getReceivedMatchings(
             userId = userId,
             request = request,
         )
+
+        return ApiResponse.success(response)
     }
 
     @Operation(
@@ -69,10 +73,12 @@ class MyMatchingController(
     fun getSentMatchings(
         @RequestHeader("userId") userId: String, // TODO: 인증/인가 적용 시 변경
         @Valid request: CommonCursorRequest,
-    ): CursorResponse<SentMatchingSummaryResponse> {
-        return matchingService.getSentMatchings(
+    ): ResponseEntity<ApiResponse<CursorResponse<SentMatchingSummaryResponse>>> {
+        val response = matchingService.getSentMatchings(
             userId = userId,
             request = request,
         )
+
+        return ApiResponse.success(response)
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/controller/MyMatchingController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/controller/MyMatchingController.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.appjam.smashing.domain.matching.service.MatchingService
 import org.appjam.smashing.domain.matching.dto.response.ReceivedMatchingSummaryResponse
+import org.appjam.smashing.domain.matching.dto.response.SentMatchingSummaryResponse
 import org.appjam.smashing.global.common.dto.CommonCursorRequest
 import org.appjam.smashing.global.common.dto.CursorResponse
 import org.springframework.web.bind.annotation.GetMapping
@@ -41,6 +42,35 @@ class MyMatchingController(
         @Valid request: CommonCursorRequest,
     ): CursorResponse<ReceivedMatchingSummaryResponse> {
         return matchingService.getReceivedMatchings(
+            userId = userId,
+            request = request,
+        )
+    }
+
+    @Operation(
+        summary = "내가 보낸 매칭 요청 목록 조회 API",
+        description = """
+            내가 보낸 매칭 요청(REQUESTED 상태) 목록을 조회합니다.
+            - 정렬 기준
+             - 최신순: matching.id DESC (TSID 기반 최신순)
+            - 페이징 방식
+             - cursor(keyset) 기반 페이징
+             - nextCursor는 "마지막 matching id"로 생성.
+             - 다음 페이지 요청 시 cursor에 nextCursor를 전달.
+            - 스냅샷 고정
+             - 최초 요청에서 snapshotAt이 없으면 서버가 now로 고정.
+             - 다음 페이지 요청부터는 응답의 snapshotAt을 그대로 재전송.
+            - 상대 정보
+             - receiver(수신자) 정보 제공
+             - gender(MALE/FEMALE) 포함
+        """
+    )
+    @GetMapping("/sent")
+    fun getSentMatchings(
+        @RequestHeader("userId") userId: String, // TODO: 인증/인가 적용 시 변경
+        @Valid request: CommonCursorRequest,
+    ): CursorResponse<SentMatchingSummaryResponse> {
+        return matchingService.getSentMatchings(
             userId = userId,
             request = request,
         )

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/dto/projection/ReceivedMatchingSummaryProjection.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/dto/projection/ReceivedMatchingSummaryProjection.kt
@@ -1,0 +1,31 @@
+package org.appjam.smashing.domain.matching.dto.projection
+
+import com.querydsl.core.annotations.QueryProjection
+import org.appjam.smashing.domain.matching.enums.MatchingStatus
+import org.appjam.smashing.domain.user.enums.Gender
+import org.appjam.smashing.global.common.dto.CursorKey
+import org.appjam.smashing.global.util.TimeUtils
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+
+@QueryProjection
+data class ReceivedMatchingSummaryProjection(
+    val matchingId: String,
+    val createdAtLdt: LocalDateTime,
+    val status: MatchingStatus,
+    val requesterUserId: String,
+    val requesterNickname: String,
+    val requesterGender: Gender,
+    val requesterReviewCount: Long,
+    val requesterTierId: Long,
+    val requesterTierName: String,
+    val requesterWins: Int,
+    val requesterLosses: Int,
+) : CursorKey {
+
+    override val cursorId: String
+        get() = matchingId
+
+    val createdAt: OffsetDateTime
+        get() = TimeUtils.toOffsetDateTime(createdAtLdt)
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/dto/projection/SentMatchingSummaryProjection.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/dto/projection/SentMatchingSummaryProjection.kt
@@ -1,0 +1,31 @@
+package org.appjam.smashing.domain.matching.dto.projection
+
+import com.querydsl.core.annotations.QueryProjection
+import org.appjam.smashing.domain.matching.enums.MatchingStatus
+import org.appjam.smashing.domain.user.enums.Gender
+import org.appjam.smashing.global.common.dto.CursorKey
+import org.appjam.smashing.global.util.TimeUtils
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+
+@QueryProjection
+data class SentMatchingSummaryProjection(
+    val matchingId: String,
+    val createdAtLdt: LocalDateTime,
+    val status: MatchingStatus,
+    val receiverUserId: String,
+    val receiverNickname: String,
+    val receiverGender: Gender,
+    val receiverReviewCount: Long,
+    val receiverTierId: Long,
+    val receiverTierName: String,
+    val receiverWins: Int,
+    val receiverLosses: Int,
+) : CursorKey {
+
+    override val cursorId: String
+        get() = matchingId
+
+    val createdAt: OffsetDateTime
+        get() = TimeUtils.toOffsetDateTime(createdAtLdt)
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/dto/response/ReceivedMatchingListResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/dto/response/ReceivedMatchingListResponse.kt
@@ -1,0 +1,47 @@
+package org.appjam.smashing.domain.matching.dto.response
+
+import org.appjam.smashing.domain.matching.enums.MatchingStatus
+import org.appjam.smashing.domain.matching.dto.projection.ReceivedMatchingSummaryProjection
+import org.appjam.smashing.domain.user.enums.Gender
+import java.time.OffsetDateTime
+
+data class ReceivedMatchingSummaryResponse(
+    val matchingId: String,
+    val createdAt: OffsetDateTime,
+    val status: MatchingStatus,
+    val requester: RequesterSummary,
+) {
+
+    data class RequesterSummary(
+        val userId: String,
+        val nickname: String,
+        val gender: Gender,
+        val reviewCount: Long,
+        val tierId: Long,
+        val tierName: String,
+        val wins: Int,
+        val losses: Int,
+    )
+
+    companion object {
+        fun from(
+            p: ReceivedMatchingSummaryProjection
+        ) = ReceivedMatchingSummaryResponse(
+            matchingId = p.matchingId,
+            createdAt = p.createdAt,
+            status = p.status,
+            requester = RequesterSummary(
+                userId = p.requesterUserId,
+                nickname = p.requesterNickname,
+                gender = p.requesterGender,
+                reviewCount = p.requesterReviewCount,
+                tierId = p.requesterTierId,
+                tierName = p.requesterTierName,
+                wins = p.requesterWins,
+                losses = p.requesterLosses,
+            )
+        )
+
+        fun from(list: List<ReceivedMatchingSummaryProjection>) = list.map(::from)
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/dto/response/SentMatchingSummaryResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/dto/response/SentMatchingSummaryResponse.kt
@@ -1,0 +1,47 @@
+package org.appjam.smashing.domain.matching.dto.response
+
+import org.appjam.smashing.domain.matching.dto.projection.SentMatchingSummaryProjection
+import org.appjam.smashing.domain.matching.enums.MatchingStatus
+import org.appjam.smashing.domain.user.enums.Gender
+import java.time.OffsetDateTime
+
+data class SentMatchingSummaryResponse(
+    val matchingId: String,
+    val createdAt: OffsetDateTime,
+    val status: MatchingStatus,
+    val receiver: ReceiverSummary,
+) {
+
+    data class ReceiverSummary(
+        val userId: String,
+        val nickname: String,
+        val gender: Gender,
+        val reviewCount: Long,
+        val tierId: Long,
+        val tierName: String,
+        val wins: Int,
+        val losses: Int,
+    )
+
+    companion object {
+        fun from(
+            p: SentMatchingSummaryProjection
+        ) = SentMatchingSummaryResponse(
+            matchingId = p.matchingId,
+            createdAt = p.createdAt,
+            status = p.status,
+            receiver = ReceiverSummary(
+                userId = p.receiverUserId,
+                nickname = p.receiverNickname,
+                gender = p.receiverGender,
+                reviewCount = p.receiverReviewCount,
+                tierId = p.receiverTierId,
+                tierName = p.receiverTierName,
+                wins = p.receiverWins,
+                losses = p.receiverLosses,
+            )
+        )
+
+        fun from(list: List<SentMatchingSummaryProjection>) = list.map(::from)
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepository.kt
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
 
-interface MatchingRepository : JpaRepository<Matching, String> {
+interface MatchingRepository : JpaRepository<Matching, String>, MatchingRepositoryCustom {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query(

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepositoryCustom.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepositoryCustom.kt
@@ -1,0 +1,16 @@
+package org.appjam.smashing.domain.matching.repository
+
+import org.appjam.smashing.domain.matching.dto.projection.ReceivedMatchingSummaryProjection
+import org.appjam.smashing.global.common.dto.CommonCursorRequest
+import org.appjam.smashing.global.common.dto.CursorPageResponse
+import java.time.OffsetDateTime
+
+interface MatchingRepositoryCustom {
+
+    fun fetchReceivedRequestedPage(
+        receiverUserId: String,
+        sportId: Long,
+        request: CommonCursorRequest,
+        snapshotAt: OffsetDateTime,
+    ): CursorPageResponse<ReceivedMatchingSummaryProjection>
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepositoryCustom.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepositoryCustom.kt
@@ -1,6 +1,7 @@
 package org.appjam.smashing.domain.matching.repository
 
 import org.appjam.smashing.domain.matching.dto.projection.ReceivedMatchingSummaryProjection
+import org.appjam.smashing.domain.matching.dto.projection.SentMatchingSummaryProjection
 import org.appjam.smashing.global.common.dto.CommonCursorRequest
 import org.appjam.smashing.global.common.dto.CursorPageResponse
 import java.time.OffsetDateTime
@@ -13,4 +14,11 @@ interface MatchingRepositoryCustom {
         request: CommonCursorRequest,
         snapshotAt: OffsetDateTime,
     ): CursorPageResponse<ReceivedMatchingSummaryProjection>
+
+    fun fetchSentRequestedPage(
+        requesterUserId: String,
+        sportId: Long,
+        request: CommonCursorRequest,
+        snapshotAt: OffsetDateTime,
+    ): CursorPageResponse<SentMatchingSummaryProjection>
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepositoryCustomImpl.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepositoryCustomImpl.kt
@@ -4,6 +4,8 @@ import com.querydsl.core.BooleanBuilder
 import com.querydsl.jpa.JPAExpressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.appjam.smashing.domain.matching.dto.projection.QReceivedMatchingSummaryProjection
+import org.appjam.smashing.domain.matching.dto.projection.QSentMatchingSummaryProjection
+import org.appjam.smashing.domain.matching.dto.projection.SentMatchingSummaryProjection
 import org.appjam.smashing.domain.matching.entity.QMatching.Companion.matching
 import org.appjam.smashing.domain.matching.enums.MatchingStatus
 import org.appjam.smashing.domain.review.entity.QGameReview.Companion.gameReview
@@ -81,6 +83,78 @@ class MatchingRepositoryCustomImpl(
                     .and(requesterProfile.sport.id.eq(sportId))
             )
             .join(requesterProfile.tier, requesterTier)
+            .where(where)
+            .orderBy(matching.id.desc())
+            .limit((size + 1).toLong())
+            .fetch()
+
+        return CursorPageResponse.create(
+            snapshotAt = snapshotAt,
+            fetched = projections,
+            pageSize = size,
+            cursorCodec = cursorCodec,
+        )
+    }
+
+    override fun fetchSentRequestedPage(
+        requesterUserId: String,
+        sportId: Long,
+        request: CommonCursorRequest,
+        snapshotAt: OffsetDateTime,
+    ): CursorPageResponse<SentMatchingSummaryProjection> {
+
+        val size = request.size.coerceIn(1, 50).toInt()
+        val cursor = cursorCodec.decode(request.cursor)
+
+        val snapshotLocal = snapshotAt
+            .atZoneSameInstant(TimeUtils.DEFAULT_ZONE_ID)
+            .toLocalDateTime()
+
+        val receiver = QUser("receiver")
+        val receiverProfile = QUserSportProfile("receiverProfile")
+        val receiverTier = QTier("receiverTier")
+
+        val where = BooleanBuilder()
+            .and(matching.requester.id.eq(requesterUserId))
+            .and(matching.sport.id.eq(sportId))
+            .and(matching.status.eq(MatchingStatus.REQUESTED))
+            .and(matching.createdAt.loe(snapshotLocal))
+
+        if (cursor != null) {
+            where.and(matching.id.lt(cursor.id))
+        }
+
+        val receiverReviewCount = JPAExpressions
+            .select(gameReview.count())
+            .from(gameReview)
+            .where(gameReview.reviewee.id.eq(receiver.id))
+
+        val projections = queryFactory
+            .select(
+                QSentMatchingSummaryProjection(
+                    matching.id,
+                    matching.createdAt,
+                    matching.status,
+
+                    receiver.id,
+                    receiver.nickname,
+                    receiver.gender,
+
+                    receiverReviewCount,
+
+                    receiverTier.id,
+                    receiverTier.name,
+                    receiverProfile.wins,
+                    receiverProfile.losses,
+                )
+            )
+            .from(matching)
+            .join(matching.receiver, receiver)
+            .join(receiverProfile).on(
+                receiverProfile.user.eq(receiver)
+                    .and(receiverProfile.sport.id.eq(sportId))
+            )
+            .join(receiverProfile.tier, receiverTier)
             .where(where)
             .orderBy(matching.id.desc())
             .limit((size + 1).toLong())

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepositoryCustomImpl.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepositoryCustomImpl.kt
@@ -1,0 +1,96 @@
+package org.appjam.smashing.domain.matching.repository
+
+import com.querydsl.core.BooleanBuilder
+import com.querydsl.jpa.JPAExpressions
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.appjam.smashing.domain.matching.dto.projection.QReceivedMatchingSummaryProjection
+import org.appjam.smashing.domain.matching.entity.QMatching.Companion.matching
+import org.appjam.smashing.domain.matching.enums.MatchingStatus
+import org.appjam.smashing.domain.review.entity.QGameReview.Companion.gameReview
+import org.appjam.smashing.domain.tier.entity.QTier
+import org.appjam.smashing.domain.user.entity.QUser
+import org.appjam.smashing.domain.user.entity.QUserSportProfile
+import org.appjam.smashing.domain.matching.dto.projection.ReceivedMatchingSummaryProjection
+import org.appjam.smashing.global.common.dto.CommonCursorRequest
+import org.appjam.smashing.global.common.dto.CursorPageResponse
+import org.appjam.smashing.global.util.CursorCodec
+import org.appjam.smashing.global.util.TimeUtils
+import org.springframework.stereotype.Repository
+import java.time.OffsetDateTime
+
+@Repository
+class MatchingRepositoryCustomImpl(
+    private val queryFactory: JPAQueryFactory,
+    private val cursorCodec: CursorCodec,
+) : MatchingRepositoryCustom {
+
+    override fun fetchReceivedRequestedPage(
+        receiverUserId: String,
+        sportId: Long,
+        request: CommonCursorRequest,
+        snapshotAt: OffsetDateTime,
+    ): CursorPageResponse<ReceivedMatchingSummaryProjection> {
+
+        val size = request.size.coerceIn(1, 50).toInt()
+        val cursor = cursorCodec.decode(request.cursor)
+
+        val snapshotLocal = snapshotAt
+            .atZoneSameInstant(TimeUtils.DEFAULT_ZONE_ID)
+            .toLocalDateTime()
+
+        val requester = QUser("requester")
+        val requesterProfile = QUserSportProfile("requesterProfile")
+        val requesterTier = QTier("requesterTier")
+
+        val where = BooleanBuilder()
+            .and(matching.receiver.id.eq(receiverUserId))
+            .and(matching.sport.id.eq(sportId))
+            .and(matching.status.eq(MatchingStatus.REQUESTED))
+            .and(matching.createdAt.loe(snapshotLocal))
+
+        if (cursor != null) {
+            where.and(matching.id.lt(cursor.id))
+        }
+
+        // requester(상대)가 reviewee인 후기 개수
+        val requesterReviewCount = JPAExpressions
+            .select(gameReview.count())
+            .from(gameReview)
+            .where(gameReview.reviewee.id.eq(requester.id))
+
+        val projections = queryFactory
+            .select(
+                QReceivedMatchingSummaryProjection(
+                    matching.id,
+                    matching.createdAt,
+                    matching.status,
+                    requester.id,
+                    requester.nickname,
+                    requester.gender,
+                    requesterReviewCount,
+                    requesterTier.id,
+                    requesterTier.name,
+                    requesterProfile.wins,
+                    requesterProfile.losses,
+                )
+            )
+            .from(matching)
+            .join(matching.requester, requester)
+            .join(requesterProfile).on(
+                requesterProfile.user.eq(requester)
+                    .and(requesterProfile.sport.id.eq(sportId))
+            )
+            .join(requesterProfile.tier, requesterTier)
+            .where(where)
+            .orderBy(matching.id.desc())
+            .limit((size + 1).toLong())
+            .fetch()
+
+        return CursorPageResponse.create(
+            snapshotAt = snapshotAt,
+            fetched = projections,
+            pageSize = size,
+            cursorCodec = cursorCodec,
+        )
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepositoryCustomImpl.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepositoryCustomImpl.kt
@@ -17,10 +17,8 @@ import org.appjam.smashing.global.common.dto.CommonCursorRequest
 import org.appjam.smashing.global.common.dto.CursorPageResponse
 import org.appjam.smashing.global.util.CursorCodec
 import org.appjam.smashing.global.util.TimeUtils
-import org.springframework.stereotype.Repository
 import java.time.OffsetDateTime
 
-@Repository
 class MatchingRepositoryCustomImpl(
     private val queryFactory: JPAQueryFactory,
     private val cursorCodec: CursorCodec,

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
@@ -16,6 +16,7 @@ import org.appjam.smashing.domain.outbox.enums.MatchingUpdateStatus
 import org.appjam.smashing.domain.outbox.enums.SseEventType
 import org.appjam.smashing.domain.review.repository.GameReviewRepository
 import org.appjam.smashing.domain.matching.dto.response.ReceivedMatchingSummaryResponse
+import org.appjam.smashing.domain.matching.dto.response.SentMatchingSummaryResponse
 import org.appjam.smashing.domain.user.entity.User
 import org.appjam.smashing.domain.user.entity.UserSportProfile
 import org.appjam.smashing.domain.user.repository.UserRepository
@@ -246,6 +247,41 @@ class MatchingService(
         return CursorResponse(
             snapshotAt = response.snapshotAt,
             results = ReceivedMatchingSummaryResponse.from(response.results),
+            nextCursor = response.nextCursor,
+            hasNext = response.hasNext,
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun getSentMatchings(
+        userId: String,
+        request: CommonCursorRequest,
+    ): CursorResponse<SentMatchingSummaryResponse> {
+
+        val user = userRepository.findByIdOrNull(userId)
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+
+        val activeProfileId = user.activeUserSportProfileId
+            ?: throw CustomException(ErrorCode.USER_SPORT_PROFILE_NOT_FOUND)
+
+        val activeProfile = userSportProfileRepository.findByIdOrNull(activeProfileId)
+            ?: throw CustomException(ErrorCode.USER_SPORT_PROFILE_NOT_FOUND)
+
+        val sportId = activeProfile.sport.id
+            ?: throw CustomException(ErrorCode.SPORT_NOT_FOUND)
+
+        val snapshotAt = request.snapshotAt ?: TimeUtils.nowOffsetDateTime()
+
+        val response = matchingRepository.fetchSentRequestedPage(
+            requesterUserId = userId,
+            sportId = sportId,
+            request = request,
+            snapshotAt = snapshotAt,
+        )
+
+        return CursorResponse(
+            snapshotAt = response.snapshotAt,
+            results = SentMatchingSummaryResponse.from(response.results),
             nextCursor = response.nextCursor,
             hasNext = response.hasNext,
         )

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
@@ -15,12 +15,16 @@ import org.appjam.smashing.domain.outbox.dto.MatchingUpdatedPayload
 import org.appjam.smashing.domain.outbox.enums.MatchingUpdateStatus
 import org.appjam.smashing.domain.outbox.enums.SseEventType
 import org.appjam.smashing.domain.review.repository.GameReviewRepository
+import org.appjam.smashing.domain.matching.dto.response.ReceivedMatchingSummaryResponse
 import org.appjam.smashing.domain.user.entity.User
 import org.appjam.smashing.domain.user.entity.UserSportProfile
 import org.appjam.smashing.domain.user.repository.UserRepository
 import org.appjam.smashing.domain.user.repository.UserSportProfileRepository
+import org.appjam.smashing.global.common.dto.CommonCursorRequest
+import org.appjam.smashing.global.common.dto.CursorResponse
 import org.appjam.smashing.global.exception.CustomException
 import org.appjam.smashing.global.exception.ErrorCode
+import org.appjam.smashing.global.util.TimeUtils
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -209,6 +213,41 @@ class MatchingService(
         publishMatchingUpdatedCancelled(
             receiverUserId = matching.receiver.id!!,
             matchingId = matchingId,
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun getReceivedMatchings(
+        userId: String,
+        request: CommonCursorRequest,
+    ): CursorResponse<ReceivedMatchingSummaryResponse> {
+
+        val user = userRepository.findByIdOrNull(userId)
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
+
+        val activeProfileId = user.activeUserSportProfileId
+            ?: throw CustomException(ErrorCode.USER_SPORT_PROFILE_NOT_FOUND)
+
+        val activeProfile = userSportProfileRepository.findByIdOrNull(activeProfileId)
+            ?: throw CustomException(ErrorCode.USER_SPORT_PROFILE_NOT_FOUND)
+
+        val sportId = activeProfile.sport.id
+            ?: throw CustomException(ErrorCode.SPORT_NOT_FOUND)
+
+        val snapshotAt = request.snapshotAt ?: TimeUtils.nowOffsetDateTime()
+
+        val response = matchingRepository.fetchReceivedRequestedPage(
+            receiverUserId = userId,
+            sportId = sportId,
+            request = request,
+            snapshotAt = snapshotAt,
+        )
+
+        return CursorResponse(
+            snapshotAt = response.snapshotAt,
+            results = ReceivedMatchingSummaryResponse.from(response.results),
+            nextCursor = response.nextCursor,
+            hasNext = response.hasNext,
         )
     }
 

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
@@ -75,6 +75,7 @@ class MatchingService(
         // 알림 생성
         val savedNotification = notificationService.createMatchingRequested(
             receiver = receiverProfile.user,
+            receiverProfile = receiverProfile,
             requesterProfile = requesterProfile,
         )
 
@@ -126,9 +127,15 @@ class MatchingService(
 
         val receiverProfile = findUserProfileBySport(receiverUserId, matching.sport.id!!)
 
+        val requesterProfile = findUserProfileBySport(
+            userId = matching.requester.id!!,
+            sportId = matching.sport.id!!,
+        )
+
         // 알림 생성
         val savedNotification = notificationService.createMatchingAccepted(
             receiver = matching.requester,
+            receiverProfile = requesterProfile,
             acceptorProfile = receiverProfile,
         )
 

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/controller/NotificationController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/controller/NotificationController.kt
@@ -1,9 +1,14 @@
 package org.appjam.smashing.domain.notification.controller
 
 import io.swagger.v3.oas.annotations.Operation
+import jakarta.validation.Valid
+import org.appjam.smashing.domain.notification.dto.response.NotificationSummaryResponse
 import org.appjam.smashing.domain.notification.service.NotificationService
 import org.appjam.smashing.global.common.dto.ApiResponse
+import org.appjam.smashing.global.common.dto.CommonCursorRequest
+import org.appjam.smashing.global.common.dto.CursorResponse
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestHeader
@@ -35,5 +40,31 @@ class NotificationController(
         )
 
         return ApiResponse.success()
+    }
+
+    @Operation(
+        summary = "받은 알림 목록 조회 API",
+        description = """
+            사용자가 받은 알림 목록을 조회합니다.
+            - 정렬 기준
+             - 최신순: notification.id DESC (TSID 기반 최신순)
+            - 페이징 방식
+             - cursor(keyset) 기반 페이징
+             - nextCursor는 "마지막 알림 id"를 기준으로 생성됩니다.
+             - 다음 페이지 요청 시 cursor에 nextCursor.
+            - 스냅샷 고정
+            - 최초 요청에서 snapshotAt이 없으면 서버가 now로 고정하여 내려줍니다.
+            - 다음 페이지 요청부터는 응답의 snapshotAt을 그대로 재전송.
+        """
+    )
+    @GetMapping("/me")
+    fun getMyNotifications(
+        @RequestHeader("userId") userId: String, // TODO: 인증/인가 적용 시 변경
+        request: CommonCursorRequest,
+    ): CursorResponse<NotificationSummaryResponse> {
+        return notificationService.getMyNotifications(
+            userId = userId,
+            request = request,
+        )
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/controller/NotificationController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/controller/NotificationController.kt
@@ -60,7 +60,7 @@ class NotificationController(
     @GetMapping("/me")
     fun getMyNotifications(
         @RequestHeader("userId") userId: String, // TODO: 인증/인가 적용 시 변경
-        request: CommonCursorRequest,
+        @Valid request: CommonCursorRequest,
     ): ResponseEntity<ApiResponse<CursorResponse<NotificationSummaryResponse>>> {
         val response = notificationService.getMyNotifications(
             userId = userId,

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/controller/NotificationController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/controller/NotificationController.kt
@@ -61,10 +61,12 @@ class NotificationController(
     fun getMyNotifications(
         @RequestHeader("userId") userId: String, // TODO: 인증/인가 적용 시 변경
         request: CommonCursorRequest,
-    ): CursorResponse<NotificationSummaryResponse> {
-        return notificationService.getMyNotifications(
+    ): ResponseEntity<ApiResponse<CursorResponse<NotificationSummaryResponse>>> {
+        val response = notificationService.getMyNotifications(
             userId = userId,
             request = request,
         )
+
+        return ApiResponse.success(response)
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/dto/projection/NotificationSummaryProjection.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/dto/projection/NotificationSummaryProjection.kt
@@ -1,0 +1,29 @@
+package org.appjam.smashing.domain.notification.dto.projection
+
+import com.querydsl.core.annotations.QueryProjection
+import org.appjam.smashing.domain.notification.enums.NotificationType
+import org.appjam.smashing.global.common.dto.CursorKey
+import org.appjam.smashing.global.util.TimeUtils
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+
+@QueryProjection
+data class NotificationSummaryProjection(
+    val notificationId: String,
+    val type: NotificationType,
+    val templateTitle: String,
+    val templateContent: String,
+    val params: String,
+    val linkUrl: String,
+    val isRead: Boolean,
+    val createdAtLdt: LocalDateTime,
+    val receiverProfileId: String,
+    val receiverSportId: Long,
+) : CursorKey {
+
+    override val cursorId: String
+        get() = notificationId
+
+    val createdAt: OffsetDateTime
+        get() = TimeUtils.toOffsetDateTime(createdAtLdt)
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/dto/response/NotificationSummaryResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/dto/response/NotificationSummaryResponse.kt
@@ -1,0 +1,39 @@
+package org.appjam.smashing.domain.notification.dto.response
+
+import org.appjam.smashing.domain.notification.dto.projection.NotificationSummaryProjection
+import org.appjam.smashing.domain.notification.enums.NotificationType
+import java.time.OffsetDateTime
+
+data class NotificationSummaryResponse(
+    val notificationId: String,
+    val type: NotificationType,
+    val templateTitle: String,
+    val templateContent: String,
+    val params: String,
+    val linkUrl: String,
+    val isRead: Boolean,
+    val createdAt: OffsetDateTime,
+    val receiverProfileId: String,
+    val receiverSportId: Long,
+) {
+    companion object {
+        fun from(
+            p: NotificationSummaryProjection
+        ) = NotificationSummaryResponse(
+                notificationId = p.notificationId,
+                type = p.type,
+                templateTitle = p.templateTitle,
+                templateContent = p.templateContent,
+                params = p.params,
+                linkUrl = p.linkUrl,
+                isRead = p.isRead,
+                createdAt = p.createdAt,
+                receiverProfileId = p.receiverProfileId,
+                receiverSportId = p.receiverSportId,
+            )
+
+        fun from(
+            list: List<NotificationSummaryProjection>
+        ) = list.map(::from)
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/entity/Notification.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/entity/Notification.kt
@@ -90,7 +90,7 @@ class Notification(
         ) = Notification(
                 params = """{"acceptorNickname":"${acceptorProfile.user.nickname}","acceptorTierId":${acceptorProfile.tier.id!!}}""",
                 isRead = false,
-                linkUrl = "/api/v1/users/me/matchings/accepted/pending-result",
+                linkUrl = "/api/v1/users/me/games/pending-results",
                 receiverProfileId = receiverProfile.id!!,
                 receiverSportId = receiverProfile.sport.id!!,
                 user = receiver,
@@ -108,7 +108,7 @@ class Notification(
         ) = Notification(
             params = """{"submitterNickname":"$submitterNickname","submitterTierId":$submitterTierId,"gameId":"$gameId","submissionId":"$submissionId"}""",
             isRead = false,
-            linkUrl = "/api/v1/users/me/matchings/accepted/pending-result",
+            linkUrl = "/api/v1/users/me/games/pending-results",
             user = receiver,
             receiverProfileId = receiverProfile.id!!,
             receiverSportId = receiverProfile.sport.id!!,
@@ -144,7 +144,7 @@ class Notification(
         ) = Notification(
             params = """{"rejectorNickname":"$rejectorNickname","rejectorTierId":$rejectorTierId,"gameId":"$gameId","submissionId":"$submissionId","reason":"${GameResultRejectReason.SCORE_MISMATCH.name}"}""",
             isRead = false,
-            linkUrl = "/api/v1/users/me/matchings/accepted/pending-result",
+            linkUrl = "/api/v1/users/me/games/pending-results",
             user = receiver,
             receiverProfileId = receiverProfile.id!!,
             receiverSportId = receiverProfile.sport.id!!,
@@ -162,7 +162,7 @@ class Notification(
         ) = Notification(
             params = """{"rejectorNickname":"$rejectorNickname","rejectorTierId":$rejectorTierId,"gameId":"$gameId","submissionId":"$submissionId","reason":"${GameResultRejectReason.WIN_LOSE_REVERSED.name}"}""",
             isRead = false,
-            linkUrl = "/api/v1/users/me/matchings/accepted/pending-result",
+            linkUrl = "/api/v1/users/me/games/pending-results",
             user = receiver,
             receiverProfileId = receiverProfile.id!!,
             receiverSportId = receiverProfile.sport.id!!,

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/entity/Notification.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/entity/Notification.kt
@@ -15,8 +15,6 @@ import org.hibernate.annotations.SQLRestriction
     indexes = [
         Index(name = "idx_notification_user_id", columnList = "user_id"),
         Index(name = "idx_notification_template_id", columnList = "notification_template_id"),
-        Index(name = "idx_notification_receiver_profile_id", columnList = "receiver_profile_id"),
-        Index(name = "idx_notification_receiver_sport_id", columnList = "receiver_sport_id"),
     ]
 )
 @Comment("알림 정보")

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/entity/Notification.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/entity/Notification.kt
@@ -15,6 +15,8 @@ import org.hibernate.annotations.SQLRestriction
     indexes = [
         Index(name = "idx_notification_user_id", columnList = "user_id"),
         Index(name = "idx_notification_template_id", columnList = "notification_template_id"),
+        Index(name = "idx_notification_receiver_profile_id", columnList = "receiver_profile_id"),
+        Index(name = "idx_notification_receiver_sport_id", columnList = "receiver_sport_id"),
     ]
 )
 @Comment("알림 정보")
@@ -39,6 +41,14 @@ class Notification(
     @Comment("알림 연결 URL(라우팅 경로)")
     val linkUrl: String,
 
+    @Column(name = "receiver_profile_id", nullable = false, length = 13)
+    @Comment("수신자 유저-스포츠 프로필 IDX")
+    val receiverProfileId: String,
+
+    @Column(name = "receiver_sport_id", nullable = false)
+    @Comment("수신 스포츠 IDX")
+    val receiverSportId: Long,
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(
         name = "user_id",
@@ -61,30 +71,37 @@ class Notification(
     companion object {
         fun createMatchingRequested(
             receiver: User,
+            receiverProfile: UserSportProfile,
             template: NotificationTemplate,
             requesterProfile: UserSportProfile,
         ) = Notification(
                 params = """{"requesterNickname":"${requesterProfile.user.nickname}","requesterTierName":"${requesterProfile.tier.name}"}""",
                 isRead = false,
                 linkUrl = "/api/v1/users/me/matchings/received",
+                receiverProfileId = receiverProfile.id!!,
+                receiverSportId = receiverProfile.sport.id!!,
                 user = receiver,
                 notificationTemplate = template,
             )
 
         fun createMatchingRequestAccepted(
             receiver: User,
+            receiverProfile: UserSportProfile,
             template: NotificationTemplate,
             acceptorProfile: UserSportProfile,
         ) = Notification(
                 params = """{"acceptorNickname":"${acceptorProfile.user.nickname}","acceptorTierId":${acceptorProfile.tier.id!!}}""",
                 isRead = false,
                 linkUrl = "/api/v1/users/me/matchings/accepted/pending-result",
+                receiverProfileId = receiverProfile.id!!,
+                receiverSportId = receiverProfile.sport.id!!,
                 user = receiver,
                 notificationTemplate = template,
             )
 
         fun createMatchingResultSubmitted(
             receiver: User,
+            receiverProfile: UserSportProfile,
             template: NotificationTemplate,
             gameId: String,
             submissionId: String,
@@ -95,11 +112,14 @@ class Notification(
             isRead = false,
             linkUrl = "/api/v1/users/me/matchings/accepted/pending-result",
             user = receiver,
+            receiverProfileId = receiverProfile.id!!,
+            receiverSportId = receiverProfile.sport.id!!,
             notificationTemplate = template,
         )
 
         fun createReviewReceived(
             receiver: User,
+            receiverProfile: UserSportProfile,
             template: NotificationTemplate,
             reviewId: String,
             reviewerNickname: String,
@@ -110,11 +130,14 @@ class Notification(
             isRead = false,
             linkUrl = "/api/v1/reviews/$reviewId",
             user = receiver,
+            receiverProfileId = receiverProfile.id!!,
+            receiverSportId = receiverProfile.sport.id!!,
             notificationTemplate = template,
         )
 
         fun createResultRejectedScoreMismatch(
             receiver: User,
+            receiverProfile: UserSportProfile,
             template: NotificationTemplate,
             gameId: String,
             submissionId: String,
@@ -125,11 +148,14 @@ class Notification(
             isRead = false,
             linkUrl = "/api/v1/users/me/matchings/accepted/pending-result",
             user = receiver,
+            receiverProfileId = receiverProfile.id!!,
+            receiverSportId = receiverProfile.sport.id!!,
             notificationTemplate = template,
         )
 
         fun createResultRejectedWinLoseReversed(
             receiver: User,
+            receiverProfile: UserSportProfile,
             template: NotificationTemplate,
             gameId: String,
             submissionId: String,
@@ -140,6 +166,8 @@ class Notification(
             isRead = false,
             linkUrl = "/api/v1/users/me/matchings/accepted/pending-result",
             user = receiver,
+            receiverProfileId = receiverProfile.id!!,
+            receiverSportId = receiverProfile.sport.id!!,
             notificationTemplate = template,
         )
     }

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/repository/NotificationRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/repository/NotificationRepository.kt
@@ -4,7 +4,7 @@ import org.appjam.smashing.domain.notification.entity.Notification
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
-interface NotificationRepository : JpaRepository<Notification, String> {
+interface NotificationRepository : JpaRepository<Notification, String>, NotificationRepositoryCustom {
 
     @Query(
         """

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/repository/NotificationRepositoryCustom.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/repository/NotificationRepositoryCustom.kt
@@ -1,0 +1,15 @@
+package org.appjam.smashing.domain.notification.repository
+
+import org.appjam.smashing.domain.notification.dto.projection.NotificationSummaryProjection
+import org.appjam.smashing.global.common.dto.CommonCursorRequest
+import org.appjam.smashing.global.common.dto.CursorPageResponse
+import java.time.OffsetDateTime
+
+interface NotificationRepositoryCustom {
+
+    fun fetchMyNotificationPage(
+        userId: String,
+        request: CommonCursorRequest,
+        snapshotAt: OffsetDateTime,
+    ): CursorPageResponse<NotificationSummaryProjection>
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/repository/NotificationRepositoryCustomImpl.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/repository/NotificationRepositoryCustomImpl.kt
@@ -1,0 +1,67 @@
+package org.appjam.smashing.domain.notification.repository
+
+import com.querydsl.core.BooleanBuilder
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.appjam.smashing.domain.notification.dto.projection.NotificationSummaryProjection
+import org.appjam.smashing.domain.notification.dto.projection.QNotificationSummaryProjection
+import org.appjam.smashing.domain.notification.entity.QNotification.Companion.notification
+import org.appjam.smashing.domain.notification.entity.QNotificationTemplate.Companion.notificationTemplate
+import org.appjam.smashing.global.common.dto.CommonCursorRequest
+import org.appjam.smashing.global.common.dto.CursorPageResponse
+import org.appjam.smashing.global.util.CursorCodec
+import org.springframework.stereotype.Repository
+import java.time.OffsetDateTime
+
+@Repository
+class NotificationRepositoryCustomImpl(
+    private val queryFactory: JPAQueryFactory,
+    private val cursorCodec: CursorCodec,
+) : NotificationRepositoryCustom {
+
+    override fun fetchMyNotificationPage(
+        userId: String,
+        request: CommonCursorRequest,
+        snapshotAt: OffsetDateTime,
+    ): CursorPageResponse<NotificationSummaryProjection> {
+
+        val size = request.size.coerceIn(1, 50).toInt()
+        val cursor = cursorCodec.decode(request.cursor)
+
+        val where = BooleanBuilder()
+            .and(notification.user.id.eq(userId))
+            .and(notification.createdAt.loe(snapshotAt.toLocalDateTime()))
+
+        if (cursor != null) {
+            where.and(notification.id.lt(cursor.id))
+        }
+
+        val fetched = queryFactory
+            .select(
+                QNotificationSummaryProjection(
+                    notification.id,
+                    notificationTemplate.type,
+                    notificationTemplate.title,
+                    notificationTemplate.content,
+                    notification.params,
+                    notification.linkUrl,
+                    notification.isRead,
+                    notification.createdAt,
+                    notification.receiverProfileId,
+                    notification.receiverSportId,
+                )
+            )
+            .from(notification)
+            .join(notification.notificationTemplate, notificationTemplate)
+            .where(where)
+            .orderBy(notification.id.desc())
+            .limit((size + 1).toLong())
+            .fetch()
+
+        return CursorPageResponse.create(
+            snapshotAt = snapshotAt,
+            fetched = fetched,
+            pageSize = size,
+            cursorCodec = cursorCodec,
+        )
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/repository/NotificationRepositoryCustomImpl.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/repository/NotificationRepositoryCustomImpl.kt
@@ -9,10 +9,8 @@ import org.appjam.smashing.domain.notification.entity.QNotificationTemplate.Comp
 import org.appjam.smashing.global.common.dto.CommonCursorRequest
 import org.appjam.smashing.global.common.dto.CursorPageResponse
 import org.appjam.smashing.global.util.CursorCodec
-import org.springframework.stereotype.Repository
 import java.time.OffsetDateTime
 
-@Repository
 class NotificationRepositoryCustomImpl(
     private val queryFactory: JPAQueryFactory,
     private val cursorCodec: CursorCodec,

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/service/NotificationService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/service/NotificationService.kt
@@ -1,13 +1,17 @@
 package org.appjam.smashing.domain.notification.service
 
+import org.appjam.smashing.domain.notification.dto.response.NotificationSummaryResponse
 import org.appjam.smashing.domain.notification.entity.Notification
 import org.appjam.smashing.domain.notification.enums.NotificationType
 import org.appjam.smashing.domain.notification.repository.NotificationRepository
 import org.appjam.smashing.domain.notification.repository.NotificationTemplateRepository
 import org.appjam.smashing.domain.user.entity.User
 import org.appjam.smashing.domain.user.entity.UserSportProfile
+import org.appjam.smashing.global.common.dto.CommonCursorRequest
+import org.appjam.smashing.global.common.dto.CursorResponse
 import org.appjam.smashing.global.exception.CustomException
 import org.appjam.smashing.global.exception.ErrorCode
+import org.appjam.smashing.global.util.TimeUtils
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -19,6 +23,7 @@ class NotificationService(
 
     fun createMatchingRequested(
         receiver: User,
+        receiverProfile: UserSportProfile,
         requesterProfile: UserSportProfile,
     ): Notification {
         val template = notificationTemplateRepository.findByType(NotificationType.MATCHING_REQUESTED)
@@ -27,6 +32,7 @@ class NotificationService(
         return notificationRepository.save(
             Notification.createMatchingRequested(
                 receiver = receiver,
+                receiverProfile = receiverProfile,
                 template = template,
                 requesterProfile = requesterProfile,
             )
@@ -35,6 +41,7 @@ class NotificationService(
 
     fun createMatchingAccepted(
         receiver: User,
+        receiverProfile: UserSportProfile,
         acceptorProfile: UserSportProfile,
     ): Notification {
         val template = notificationTemplateRepository.findByType(NotificationType.MATCHING_ACCEPTED)
@@ -43,6 +50,7 @@ class NotificationService(
         return notificationRepository.save(
             Notification.createMatchingRequestAccepted(
                 receiver = receiver,
+                receiverProfile = receiverProfile,
                 template = template,
                 acceptorProfile = acceptorProfile,
             )
@@ -51,6 +59,7 @@ class NotificationService(
 
     fun createMatchingResultSubmitted(
         receiver: User,
+        receiverProfile: UserSportProfile,
         gameId: String,
         submissionId: String,
         submitterNickname: String,
@@ -62,6 +71,7 @@ class NotificationService(
         return notificationRepository.save(
             Notification.createMatchingResultSubmitted(
                 receiver = receiver,
+                receiverProfile = receiverProfile,
                 template = template,
                 gameId = gameId,
                 submissionId = submissionId,
@@ -73,6 +83,7 @@ class NotificationService(
 
     fun createReviewReceived(
         receiver: User,
+        receiverProfile: UserSportProfile,
         reviewId: String,
         reviewerNickname: String,
         reviewerTierId: Long,
@@ -84,6 +95,7 @@ class NotificationService(
         return notificationRepository.save(
             Notification.createReviewReceived(
                 receiver = receiver,
+                receiverProfile = receiverProfile,
                 template = template,
                 reviewId = reviewId,
                 reviewerNickname = reviewerNickname,
@@ -95,6 +107,7 @@ class NotificationService(
 
     fun createResultRejected(
         receiver: User,
+        receiverProfile: UserSportProfile,
         notificationType: NotificationType,
         gameId: String,
         submissionId: String,
@@ -108,6 +121,7 @@ class NotificationService(
             NotificationType.RESULT_REJECTED_SCORE_MISMATCH ->
                 Notification.createResultRejectedScoreMismatch(
                     receiver = receiver,
+                    receiverProfile = receiverProfile,
                     template = template,
                     gameId = gameId,
                     submissionId = submissionId,
@@ -118,6 +132,7 @@ class NotificationService(
             NotificationType.RESULT_REJECTED_WIN_LOSE_REVERSED ->
                 Notification.createResultRejectedWinLoseReversed(
                     receiver = receiver,
+                    receiverProfile = receiverProfile,
                     template = template,
                     gameId = gameId,
                     submissionId = submissionId,
@@ -146,5 +161,29 @@ class NotificationService(
 
         // 읽음 처리
         notification.markAsRead()
+    }
+
+    @Transactional(readOnly = true)
+    fun getMyNotifications(
+        userId: String,
+        request: CommonCursorRequest,
+    ): CursorResponse<NotificationSummaryResponse> {
+        // 스냅샷 시각 설정
+        val snapshotAt = request.snapshotAt ?: TimeUtils.nowOffsetDateTime()
+
+        // 알림 페이지 조회
+        val page = notificationRepository.fetchMyNotificationPage(
+            userId = userId,
+            request = request,
+            snapshotAt = snapshotAt,
+        )
+
+        // 응답 반환
+        return CursorResponse(
+            snapshotAt = page.snapshotAt,
+            results = NotificationSummaryResponse.from(page.results),
+            nextCursor = page.nextCursor,
+            hasNext = page.hasNext,
+        )
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/command/OpenChatValidateCommand.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/command/OpenChatValidateCommand.kt
@@ -1,4 +1,4 @@
-package org.appjam.smashing.domain.user.command
+package org.appjam.smashing.domain.user.dto.command
 
 data class OpenChatValidateCommand(
     val openchatUrl: String,

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/request/OpenChatValidateRequest.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/request/OpenChatValidateRequest.kt
@@ -1,7 +1,7 @@
 package org.appjam.smashing.domain.user.dto.request
 
 import jakarta.validation.constraints.NotBlank
-import org.appjam.smashing.domain.user.command.OpenChatValidateCommand
+import org.appjam.smashing.domain.user.dto.command.OpenChatValidateCommand
 
 data class OpenChatValidateRequest(
     @field:NotBlank(message = "openchatUrl을 입력해주세요.")

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -1,6 +1,6 @@
 package org.appjam.smashing.domain.user.service
 
-import org.appjam.smashing.domain.user.command.OpenChatValidateCommand
+import org.appjam.smashing.domain.user.dto.command.OpenChatValidateCommand
 import org.appjam.smashing.domain.user.dto.response.NicknameCheckResponse
 import org.appjam.smashing.domain.user.dto.response.OpenChatValidateResponse
 import org.appjam.smashing.domain.user.repository.UserRepository

--- a/src/main/kotlin/org/appjam/smashing/global/common/dto/CommonCursorRequest.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/common/dto/CommonCursorRequest.kt
@@ -1,0 +1,16 @@
+package org.appjam.smashing.global.common.dto
+
+import jakarta.validation.constraints.Positive
+import java.time.OffsetDateTime
+
+data class CommonCursorRequest(
+    @field:Positive(message = "페이지 사이즈는 양수입니다.")
+    val size: Long = DEFAULT_SIZE,
+    val order: String? = null,
+    val cursor: String? = null,
+    val snapshotAt: OffsetDateTime? = null,
+) {
+    companion object {
+        const val DEFAULT_SIZE: Long = 20
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/global/common/dto/CommonCursorRequest.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/common/dto/CommonCursorRequest.kt
@@ -11,6 +11,6 @@ data class CommonCursorRequest(
     val snapshotAt: OffsetDateTime? = null,
 ) {
     companion object {
-        const val DEFAULT_SIZE: Long = 20
+        private const val DEFAULT_SIZE: Long = 20
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/global/common/dto/CursorResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/common/dto/CursorResponse.kt
@@ -1,0 +1,41 @@
+package org.appjam.smashing.global.common.dto
+
+import org.appjam.smashing.global.util.CursorCodec
+import java.time.OffsetDateTime
+
+data class CursorResponse<T>(
+    val snapshotAt: OffsetDateTime,
+    val results: List<T>,
+    val nextCursor: String?,
+    val hasNext: Boolean,
+)
+
+data class CursorPageResponse<T : CursorKey>(
+    val snapshotAt: OffsetDateTime,
+    val results: List<T>,
+    val nextCursor: String?,
+    val hasNext: Boolean,
+) {
+    companion object {
+        fun <T : CursorKey> create(
+            snapshotAt: OffsetDateTime,
+            fetched: List<T>,
+            pageSize: Int,
+            cursorCodec: CursorCodec,
+        ): CursorPageResponse<T> {
+            val hasNext = fetched.size > pageSize
+            val results = if (hasNext) fetched.take(pageSize) else fetched
+
+            val nextCursor = if (hasNext && results.isNotEmpty()) {
+                cursorCodec.encode(IdCursor(id = results.last().cursorId))
+            } else null
+
+            return CursorPageResponse(
+                snapshotAt = snapshotAt,
+                results = results,
+                nextCursor = nextCursor,
+                hasNext = hasNext,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/global/common/dto/IdCursor.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/common/dto/IdCursor.kt
@@ -1,0 +1,9 @@
+package org.appjam.smashing.global.common.dto
+
+data class IdCursor(
+    val id: String,
+)
+
+interface CursorKey {
+    val cursorId: String
+}

--- a/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
@@ -46,12 +46,11 @@ enum class ErrorCode(
 
     // Domain - User / Profile
     USER_SPORT_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "USER-001", "유저 스포츠 프로필을 찾을 수 없습니다."),
-
-    // Domain - User
     NICKNAME_TOO_LONG(HttpStatus.BAD_REQUEST, "USER-002", "닉네임은 최대 10글자 이하로 가능합니다."),
     INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST, "USER-003", "특수문자는 사용할 수 없습니다."),
     DUPLICATE_OPEN_CHAT_URL(HttpStatus.CONFLICT, "USER-004", "이미 사용중인 오픈채팅방 링크입니다."),
     INVALID_OPENCHAT_FORMAT(HttpStatus.BAD_REQUEST, "USER-005", "잘못된 오픈채팅 링크 형식입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER-001", "유저 정보를 찾을 수 없습니다."),
     
     // Domain - Matching
     MATCHING_REQUESTER_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH-001", "요청자 유저를 찾을 수 없습니다."),

--- a/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
@@ -50,7 +50,7 @@ enum class ErrorCode(
     INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST, "USER-003", "특수문자는 사용할 수 없습니다."),
     DUPLICATE_OPEN_CHAT_URL(HttpStatus.CONFLICT, "USER-004", "이미 사용중인 오픈채팅방 링크입니다."),
     INVALID_OPENCHAT_FORMAT(HttpStatus.BAD_REQUEST, "USER-005", "잘못된 오픈채팅 링크 형식입니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER-001", "유저 정보를 찾을 수 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER-006", "유저 정보를 찾을 수 없습니다."),
     
     // Domain - Matching
     MATCHING_REQUESTER_NOT_FOUND(HttpStatus.NOT_FOUND, "MATCH-001", "요청자 유저를 찾을 수 없습니다."),

--- a/src/main/kotlin/org/appjam/smashing/global/util/CursorCodec.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/util/CursorCodec.kt
@@ -1,0 +1,35 @@
+package org.appjam.smashing.global.util
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.appjam.smashing.global.common.dto.IdCursor
+import org.springframework.stereotype.Component
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+
+@Component
+class CursorCodec(
+    private val objectMapper: ObjectMapper,
+) {
+
+    fun encode(
+        cursor: IdCursor
+    ): String {
+        val json = objectMapper.writeValueAsString(cursor)
+        return Base64.getUrlEncoder()
+            .withoutPadding()
+            .encodeToString(json.toByteArray(StandardCharsets.UTF_8))
+    }
+
+    fun decode(
+        cursor: String?
+    ): IdCursor? {
+        if (cursor.isNullOrBlank()) return null
+
+        val json = String(
+            Base64.getUrlDecoder().decode(cursor),
+            StandardCharsets.UTF_8,
+        )
+
+        return objectMapper.readValue(json, IdCursor::class.java)
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/global/util/TimeConstants.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/util/TimeConstants.kt
@@ -1,0 +1,24 @@
+package org.appjam.smashing.global.util
+
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZoneId
+
+object TimeUtils {
+    /*
+     * 기본 타임존 상수
+     */
+    val DEFAULT_ZONE_ID: ZoneId = ZoneId.of("Asia/Seoul") // TODO: 이후 사용자 기준 타임존으로 분리 예정
+
+    /*
+     * LocalDateTime -> OffsetDateTime 변환
+     */
+    fun toOffsetDateTime(
+        localDateTime: LocalDateTime
+    )= localDateTime.atZone(DEFAULT_ZONE_ID).toOffsetDateTime()
+
+    /*
+     * 현재 LocalDateTime 조회
+     */
+    fun nowOffsetDateTime() = OffsetDateTime.now(DEFAULT_ZONE_ID)
+}


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #31 

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 내 알림 목록 조회 API를 구현합니다.

- 커서 기반 페이징을 위한 공통 커서 request, 커서 데이터 구조, 커서 공통 응답 구조를 작성하였습니다! 후에 커서 기반 api 구현하실 때 참고해주시면 좋을 것같습니다 ☺️

- 알림 목록 조회 api 구현을 진행하며 알림 엔티티에 필요한 값 (수신자 유저 프로필, 수신자 유저 프로필 스포츠 정보) 가 있어 알림 엔티티를 수정하였고, 이에 맞추어 기존의 매칭, 게임 도메인에 있는 알림 생성 관련 기능들을 모두 수정하였습니다.

- 커서 기반으로 작동하여, 커서를 모르는 경우 조금 어려울 수 있습니다. 자세한 api의 내용은 노션 해당 api 명세서 페이지 한번 참고해주시면 좋을 것같습니다 🫡

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 내 알림 목록 조회 API 구현
- [x] 내가 받은 매칭 요청 목록 조회 API 구현
- [x] 내가 보낸 매칭 요청 목록 조회 API 구현
- [x] 결과 확정 전 수락된 경기 목록 조회 API 구현

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 내 알림 목록 조회 API 구현
<img width="1480" height="1382" alt="image" src="https://github.com/user-attachments/assets/765bd195-fa5d-4007-95f9-58fae9223867" />
<img width="2210" height="1376" alt="image" src="https://github.com/user-attachments/assets/ce7f9ae5-3eb0-48e9-8c07-02c7563541a9" />
<img width="2228" height="1340" alt="image" src="https://github.com/user-attachments/assets/f2b95191-2093-4112-80ed-96554b92524d" />

- 내가 받은 매칭 요청 목록 조회 API 구현
<img width="906" height="617" alt="image" src="https://github.com/user-attachments/assets/8c7baa8c-a922-423c-bbe7-ec6e301060a3" />

- 내가 보낸 매칭 요청 목록 조회 API 구현
<img width="543" height="542" alt="image" src="https://github.com/user-attachments/assets/ae4dbe83-9c30-4155-b257-ff8f1ed42fdd" />

- 결과 확정 전 수락된 경기 목록 조회 API 구현
<img width="618" height="680" alt="image" src="https://github.com/user-attachments/assets/adc69dd3-af08-45c1-935f-67b04b0d91b6" />

## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 내용