### PR TITLE
[FEAT] 후기 단건 상세 조회 API 구현

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/domain/game/dto/request/GameResultSubmitRequest.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/dto/request/GameResultSubmitRequest.kt
@@ -4,11 +4,13 @@ import jakarta.validation.Valid
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
-import jakarta.validation.constraints.Size
 import org.appjam.smashing.domain.game.dto.command.GameResultSubmitCommand
 import org.appjam.smashing.domain.review.enums.ReviewRating
 import org.appjam.smashing.domain.review.enums.ReviewTag
 import org.appjam.smashing.global.common.validator.annotation.ValidEnum
+import org.appjam.smashing.global.exception.CustomException
+import org.appjam.smashing.global.exception.ErrorCode
+import org.appjam.smashing.global.extensions.getActualLength
 import org.appjam.smashing.global.extensions.ofIgnoreCase
 import org.appjam.smashing.global.extensions.ofIgnoreCaseOrNull
 
@@ -43,15 +45,20 @@ data class GameResultSubmitRequest(
         @field:ValidEnum(message = "잘못된 rating 값입니다.", enumClass = ReviewRating::class)
         val rating: String?,
 
-        @field:Size(max = 100, message = "후기 내용은 최대 100자까지 입력 가능합니다.")
         val content: String?,
 
         val tags: Set<@ValidEnum(message = "잘못된 tag 값입니다.", enumClass = ReviewTag::class) String>?,
     ) {
-        fun toCommand() = GameResultSubmitCommand.ReviewCommand(
-            rating = ofIgnoreCase<ReviewRating>(rating!!),
-            content = content,
-            tags = tags?.mapNotNull { ofIgnoreCaseOrNull<ReviewTag>(it) }?.toSet(),
-        )
+        fun toCommand(): GameResultSubmitCommand.ReviewCommand {
+            if ((content?.getActualLength() ?: 0) > 100) {
+                throw CustomException(ErrorCode.REVIEW_CONTENT_TOO_LONG)
+            }
+
+            return GameResultSubmitCommand.ReviewCommand(
+                rating = ofIgnoreCase<ReviewRating>(rating!!),
+                content = content,
+                tags = tags?.mapNotNull { ofIgnoreCaseOrNull<ReviewTag>(it) }?.toSet(),
+            )
+        }
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/game/dto/request/GameResultSubmitRequest.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/dto/request/GameResultSubmitRequest.kt
@@ -4,6 +4,7 @@ import jakarta.validation.Valid
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Size
 import org.appjam.smashing.domain.game.dto.command.GameResultSubmitCommand
 import org.appjam.smashing.domain.review.enums.ReviewRating
 import org.appjam.smashing.domain.review.enums.ReviewTag
@@ -42,6 +43,7 @@ data class GameResultSubmitRequest(
         @field:ValidEnum(message = "잘못된 rating 값입니다.", enumClass = ReviewRating::class)
         val rating: String?,
 
+        @field:Size(max = 100, message = "후기 내용은 최대 100자까지 입력 가능합니다.")
         val content: String?,
 
         val tags: Set<@ValidEnum(message = "잘못된 tag 값입니다.", enumClass = ReviewTag::class) String>?,

--- a/src/main/kotlin/org/appjam/smashing/domain/review/controller/GameReviewController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/review/controller/GameReviewController.kt
@@ -1,0 +1,15 @@
+package org.appjam.smashing.domain.review.controller
+
+import org.appjam.smashing.domain.review.service.GameReviewService
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/reviews")
+class GameReviewController(
+    private val gameReviewService: GameReviewService,
+) {
+    fun getReview() {
+
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/review/controller/GameReviewController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/review/controller/GameReviewController.kt
@@ -17,7 +17,6 @@ class GameReviewController(
         @PathVariable("reviewId") reviewId: String,
     ): ResponseEntity<ApiResponse<ReviewDetailResponse>> {
         val response = gameReviewService.getReviewDetail(
-            userId = userId,
             reviewId = reviewId,
         )
 

--- a/src/main/kotlin/org/appjam/smashing/domain/review/controller/GameReviewController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/review/controller/GameReviewController.kt
@@ -1,15 +1,28 @@
 package org.appjam.smashing.domain.review.controller
 
+import org.appjam.smashing.domain.review.dto.response.ReviewDetailResponse
 import org.appjam.smashing.domain.review.service.GameReviewService
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.appjam.smashing.global.common.dto.ApiResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/v1/reviews")
 class GameReviewController(
     private val gameReviewService: GameReviewService,
 ) {
-    fun getReview() {
+    @GetMapping("/{reviewId}")
+    fun getReviewDetail(
+        @RequestHeader("userId") userId: String, // TODO: 인증/인가 회복시 @AuthenticationPrincipal 으로 변경
+        @PathVariable("reviewId") reviewId: String,
+    ): ResponseEntity<ApiResponse<ReviewDetailResponse>> {
+        val response = gameReviewService.getReviewDetail(
+            userId = userId,
+            reviewId = reviewId,
+        )
 
+        return ApiResponse.success(
+            data = response
+        )
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/review/dto/response/ReviewDetailResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/review/dto/response/ReviewDetailResponse.kt
@@ -3,6 +3,6 @@ package org.appjam.smashing.domain.review.dto.response
 data class ReviewDetailResponse(
     val reviewerNickname: String,
     val revieweeNickname: String,
-    val tag: String,
+    val tag: List<String>,
     val content: String,
 )

--- a/src/main/kotlin/org/appjam/smashing/domain/review/dto/response/ReviewDetailResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/review/dto/response/ReviewDetailResponse.kt
@@ -1,8 +1,21 @@
 package org.appjam.smashing.domain.review.dto.response
 
+import org.appjam.smashing.domain.review.entity.GameReview
+
 data class ReviewDetailResponse(
     val reviewerNickname: String,
     val revieweeNickname: String,
     val tag: List<String>,
     val content: String,
-)
+) {
+    companion object {
+        fun from(
+            r: GameReview,
+        ) = ReviewDetailResponse(
+            reviewerNickname = r.reviewer.nickname,
+            revieweeNickname = r.reviewee.nickname,
+            tag = r.tags.map { it.name },
+            content = r.content.orEmpty()
+        )
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/review/dto/response/ReviewDetailResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/review/dto/response/ReviewDetailResponse.kt
@@ -10,12 +10,12 @@ data class ReviewDetailResponse(
 ) {
     companion object {
         fun from(
-            r: GameReview,
+            gr: GameReview,
         ) = ReviewDetailResponse(
-            reviewerNickname = r.reviewer.nickname,
-            revieweeNickname = r.reviewee.nickname,
-            tag = r.tags.map { it.name },
-            content = r.content.orEmpty()
+            reviewerNickname = gr.reviewer.nickname,
+            revieweeNickname = gr.reviewee.nickname,
+            tag = gr.tags.map { it.name },
+            content = gr.content.orEmpty()
         )
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/review/dto/response/ReviewDetailResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/review/dto/response/ReviewDetailResponse.kt
@@ -1,0 +1,8 @@
+package org.appjam.smashing.domain.review.dto.response
+
+data class ReviewDetailResponse(
+    val reviewerNickname: String,
+    val revieweeNickname: String,
+    val tag: String,
+    val content: String,
+)

--- a/src/main/kotlin/org/appjam/smashing/domain/review/entity/GameReview.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/review/entity/GameReview.kt
@@ -4,7 +4,8 @@ import io.hypersistence.utils.hibernate.id.Tsid
 import jakarta.persistence.*
 import org.appjam.smashing.domain.common.entity.BaseEntity
 import org.appjam.smashing.domain.game.entity.Game
-import org.appjam.smashing.domain.review.enums.*
+import org.appjam.smashing.domain.review.enums.ReviewRating
+import org.appjam.smashing.domain.review.enums.ReviewTag
 import org.appjam.smashing.domain.user.entity.User
 import org.hibernate.annotations.Comment
 import org.hibernate.annotations.SQLDelete
@@ -28,7 +29,7 @@ class GameReview(
     @Comment("경기 후기 IDX")
     val id: String? = null,
 
-    @Column(columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT", length = 100)
     @Comment("후기 내용")
     var content: String? = null,
 

--- a/src/main/kotlin/org/appjam/smashing/domain/review/entity/GameReview.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/review/entity/GameReview.kt
@@ -29,7 +29,7 @@ class GameReview(
     @Comment("경기 후기 IDX")
     val id: String? = null,
 
-    @Column(columnDefinition = "TEXT", length = 100)
+    @Column(length = 100)
     @Comment("후기 내용")
     var content: String? = null,
 

--- a/src/main/kotlin/org/appjam/smashing/domain/review/enums/ReviewTag.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/review/enums/ReviewTag.kt
@@ -1,7 +1,8 @@
 package org.appjam.smashing.domain.review.enums
 
 enum class ReviewTag {
-    MANNER_GOOD,      // 경기 매너가 좋아요
+    GOOD_MANNER,      // 경기 매너가 좋아요
     ON_TIME,          // 시간 약속을 잘 지켜요
-    SPORTSMANSHIP     // 승패 깔끔 인정
+    FAIR_PLAY,        // 승패 깔끔 인정
+    FAST_RESPONSE     // 응답이 빨라요
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/review/repository/GameReviewRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/review/repository/GameReviewRepository.kt
@@ -26,6 +26,7 @@ interface GameReviewRepository : JpaRepository<GameReview, String> {
             from GameReview gr
             join fetch gr.reviewer
             join fetch gr.reviewee
+            left join fetch gr.tags
             where gr.id = :reviewId
         """
     )

--- a/src/main/kotlin/org/appjam/smashing/domain/review/repository/GameReviewRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/review/repository/GameReviewRepository.kt
@@ -19,4 +19,17 @@ interface GameReviewRepository : JpaRepository<GameReview, String> {
         revieweeUserId: String,
         sportId: Long,
     ): Long
+
+    @Query(
+        """
+            select gr
+            from GameReview gr
+            join fetch gr.reviewer
+            join fetch gr.reviewee
+            where gr.id = :reviewId
+        """
+    )
+    fun findByIdFetchAll(
+        reviewId: String,
+    ): GameReview?
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/review/service/GameReviewService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/review/service/GameReviewService.kt
@@ -51,11 +51,6 @@ class GameReviewService(
         val review = gameReviewRepository.findByIdFetchAll(reviewId)
             ?: throw CustomException(ErrorCode.REVIEW_NOT_FOUND)
 
-        return ReviewDetailResponse(
-            reviewerNickname = review.reviewer.nickname,
-            revieweeNickname = review.reviewee.nickname,
-            tag = review.tags.map { it.name },
-            content = review.content.orEmpty(),
-        )
+        return ReviewDetailResponse.from(review)
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/review/service/GameReviewService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/review/service/GameReviewService.kt
@@ -1,6 +1,7 @@
 package org.appjam.smashing.domain.review.service
 
 import org.appjam.smashing.domain.game.repository.GameRepository
+import org.appjam.smashing.domain.review.dto.response.ReviewDetailResponse
 import org.appjam.smashing.domain.review.entity.GameReview
 import org.appjam.smashing.domain.review.enums.ReviewRating
 import org.appjam.smashing.domain.review.enums.ReviewTag
@@ -41,5 +42,20 @@ class GameReviewService(
         review.tags.addAll(tags.orEmpty())
 
         return gameReviewRepository.save(review)
+    }
+
+    @Transactional(readOnly = true)
+    fun getReviewDetail(
+        reviewId: String,
+    ): ReviewDetailResponse {
+        val review = gameReviewRepository.findByIdFetchAll(reviewId)
+            ?: throw CustomException(ErrorCode.REVIEW_NOT_FOUND)
+
+        return ReviewDetailResponse(
+            reviewerNickname = review.reviewer.nickname,
+            revieweeNickname = review.reviewee.nickname,
+            tag = review.tags.map { it.name },
+            content = review.content.orEmpty(),
+        )
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
@@ -84,6 +84,9 @@ enum class ErrorCode(
     GAME_SUBMISSION_CONFIRMER_MISMATCH(HttpStatus.FORBIDDEN, "GAME-015", "해당 제출안을 확정할 권한이 없습니다."),
     GAME_RESULT_ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST, "GAME-016", "확정된 경기는 삭제할 수 없습니다."),
 
+    // Domain - Game Review
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "GAMEREVIEW-001", "해당 리뷰를 찾을 수 없습니다."),
+
     // Domain - Sport
     SPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "SPORT-001", "존재하지 않는 스포츠 코드입니다."),
 

--- a/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
@@ -86,6 +86,7 @@ enum class ErrorCode(
 
     // Domain - Game Review
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "GAMEREVIEW-001", "해당 리뷰를 찾을 수 없습니다."),
+    REVIEW_CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "GAMEREVIEW-002", "리뷰는 최대 100자까지 입력 가능합니다."),
 
     // Domain - Sport
     SPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "SPORT-001", "존재하지 않는 스포츠 코드입니다."),

--- a/src/main/kotlin/org/appjam/smashing/global/extensions/StringExtensions.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/extensions/StringExtensions.kt
@@ -1,0 +1,3 @@
+package org.appjam.smashing.global.extensions
+
+fun String.getActualLength(): Int = this.codePointCount(0, this.length)


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #50

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 후기 단건 상세 조회 API
  - 본인 경기 결과에 대한 정보과 다른 유저의 경기 결과에 대한 정보를 모두 가져와야 하기 때문에 `join fetch`를 사용했습니다.
  - `content`의 경우 Null이어도 되기 때문에 `.orEmpty()`를 통해 처리해주었습니다. 
- GameReview의 Tag 이넘 값들을 수정해주었습니다.
- content의 조건을 추가해주었습니다.
  - "100자 이내" & "이모티콘 포함" 이라는 조건을 만족 시키기 위해 이모티콘의 개수를 정화히 세는 로직이 필요했습니다. 따라서 `codePointCount`를 이용하여 실제 문자 단위를 읽을 수 있도록 해결했습니다. 

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 후기 단건 상세 조회 API 구현
- [x] 리뷰 제출 조건 도입

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 200 Ok
<img width="546" height="312" alt="image" src="https://github.com/user-attachments/assets/57aa497a-ab6a-4af8-a143-5dc2aa868467" />

- 리뷰 제출 시 이모티콘 개수 확인
<img width="1151" height="495" alt="image" src="https://github.com/user-attachments/assets/4d020c77-c3ea-45e0-9ad9-76e8f9edeabe" />

- 리뷰 조회 시 이모티콘 응답 확인
<img width="1166" height="381" alt="image" src="https://github.com/user-attachments/assets/63124e70-afad-4dca-a04f-7a1cba810d79" />


## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 이모지 허용을 위해 추가로 넣어야 할 코드가 있을까요..?