### PR TITLE
[FEAT] 사용자 프로필별 마이페이지 정보 조회 API 구현

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -62,7 +62,7 @@ class UserController(
         return ApiResponse.success()
     }
 
-    @GetMapping("me/profiles")
+    @GetMapping("/me/profiles")
     fun getUserProfiles(
         @RequestHeader("userId") userId: String, // TODO: 인증/인가 회복시 @AuthenticationPrincipal 으로 변경
     ): ResponseEntity<ApiResponse<UserProfilesResponse>> {

--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -5,10 +5,7 @@ import org.appjam.smashing.domain.user.dto.request.ActiveProfileUpdateRequest
 import org.appjam.smashing.domain.user.dto.request.AddressUpdateRequest
 import org.appjam.smashing.domain.user.dto.request.OpenChatValidateRequest
 import org.appjam.smashing.domain.user.dto.request.ProfileAddRequest
-import org.appjam.smashing.domain.user.dto.response.NicknameCheckResponse
-import org.appjam.smashing.domain.user.dto.response.OpenChatValidateResponse
-import org.appjam.smashing.domain.user.dto.response.OtherUserProfilesResponse
-import org.appjam.smashing.domain.user.dto.response.UserProfileTierResponse
+import org.appjam.smashing.domain.user.dto.response.*
 import org.appjam.smashing.domain.user.service.UserService
 import org.appjam.smashing.global.common.dto.ApiResponse
 import org.springframework.http.ResponseEntity
@@ -63,6 +60,17 @@ class UserController(
         )
 
         return ApiResponse.success()
+    }
+
+    @GetMapping("me/profiles")
+    fun getUserProfiles(
+        @RequestHeader("userId") authId: String, // TODO: 인증/인가 회복시 @AuthenticationPrincipal 으로 변경
+    ): ResponseEntity<ApiResponse<UserProfilesResponse>> {
+        val response = userService.getUserProfiles()
+
+        return ApiResponse.success(
+            data = response,
+        )
     }
 
     @GetMapping("/{userId}/profiles")

--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -64,9 +64,11 @@ class UserController(
 
     @GetMapping("me/profiles")
     fun getUserProfiles(
-        @RequestHeader("userId") authId: String, // TODO: 인증/인가 회복시 @AuthenticationPrincipal 으로 변경
+        @RequestHeader("userId") userId: String, // TODO: 인증/인가 회복시 @AuthenticationPrincipal 으로 변경
     ): ResponseEntity<ApiResponse<UserProfilesResponse>> {
-        val response = userService.getUserProfiles()
+        val response = userService.getUserProfiles(
+            userId = userId,
+        )
 
         return ApiResponse.success(
             data = response,

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUserProfilesResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUserProfilesResponse.kt
@@ -10,7 +10,7 @@ data class OtherUserProfilesResponse(
     data class SelectedProfile(
         val profileId: String,
         val sportCode: String,
-        val tierId: Int,
+        val tierId: Long,
         val lp: Int,
         val minLp: Int,
         val maxLp: Int,
@@ -23,7 +23,7 @@ data class OtherUserProfilesResponse(
             ) = SelectedProfile(
                 profileId = u.id!!,
                 sportCode = u.sport.code,
-                tierId = u.tier.orderNo,
+                tierId = u.tier.id!!,
                 lp = u.lp,
                 minLp = u.tier.minLp,
                 maxLp = u.tier.maxLp,

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUserProfilesResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUserProfilesResponse.kt
@@ -50,10 +50,10 @@ data class OtherUserProfilesResponse(
 
             fun listForm(
                 allProfiles: List<UserSportProfile>,
-                selectedSportProfileId: String,
+                selectedProfileId: String,
             ) = allProfiles.map { userSportProfile ->
                 from(
-                    isSelected = userSportProfile.id == selectedSportProfileId,
+                    isSelected = userSportProfile.id == selectedProfileId,
                     u = userSportProfile,
                 )
             }
@@ -70,7 +70,7 @@ data class OtherUserProfilesResponse(
             selectedProfile = SelectedProfile.from(selectedProfile),
             allProfiles = ProfileInfo.listForm(
                 allProfiles = allProfiles,
-                selectedSportProfileId = selectedProfile.id!!
+                selectedProfileId = selectedProfile.id!!
             )
         )
     }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUserProfilesResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUserProfilesResponse.kt
@@ -51,8 +51,7 @@ data class OtherUserProfilesResponse(
             ) = allProfiles
                 .filter { userSportProfile ->
                     userSportProfile.id != selectedSportProfileId
-                }
-                .map { userSportProfile ->
+                }.map { userSportProfile ->
                     from(userSportProfile)
                 }
         }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUserProfilesResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUserProfilesResponse.kt
@@ -4,10 +4,10 @@ import org.appjam.smashing.domain.user.entity.UserSportProfile
 
 data class OtherUserProfilesResponse(
     val nickname: String,
-    val selectedSport: SelectedSport,
-    val sports: List<SportInfo>,
+    val selectedProfile: SelectedProfile,
+    val allProfiles: List<ProfileInfo>,
 ) {
-    data class SelectedSport(
+    data class SelectedProfile(
         val profileId: String,
         val sportCode: String,
         val tierId: Int,
@@ -20,7 +20,7 @@ data class OtherUserProfilesResponse(
         companion object {
             fun from(
                 u: UserSportProfile,
-            ) = SelectedSport(
+            ) = SelectedProfile(
                 profileId = u.id!!,
                 sportCode = u.sport.code,
                 tierId = u.tier.orderNo,
@@ -33,41 +33,44 @@ data class OtherUserProfilesResponse(
         }
     }
 
-    data class SportInfo(
+    data class ProfileInfo(
         val profileId: String,
         val sportCode: String,
+        val isActive: Boolean,
     ) {
         companion object {
             fun from(
+                isActive: Boolean,
                 u: UserSportProfile,
-            ) = SportInfo(
+            ) = ProfileInfo(
                 profileId = u.id!!,
                 sportCode = u.sport.code,
+                isActive = isActive
             )
 
             fun listForm(
                 allProfiles: List<UserSportProfile>,
                 selectedSportProfileId: String,
-            ) = allProfiles
-                .filter { userSportProfile ->
-                    userSportProfile.id != selectedSportProfileId
-                }.map { userSportProfile ->
-                    from(userSportProfile)
-                }
+            ) = allProfiles.map { userSportProfile ->
+                from(
+                    isActive = userSportProfile.id == selectedSportProfileId,
+                    u = userSportProfile,
+                )
+            }
         }
     }
 
     companion object {
         fun from(
             nickname: String,
-            selectedSport: UserSportProfile,
+            selectedProfile: UserSportProfile,
             allProfiles: List<UserSportProfile>,
         ) = OtherUserProfilesResponse(
             nickname = nickname,
-            selectedSport = SelectedSport.from(selectedSport),
-            sports = SportInfo.listForm(
+            selectedProfile = SelectedProfile.from(selectedProfile),
+            allProfiles = ProfileInfo.listForm(
                 allProfiles = allProfiles,
-                selectedSportProfileId = selectedSport.id!!
+                selectedSportProfileId = selectedProfile.id!!
             )
         )
     }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUserProfilesResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUserProfilesResponse.kt
@@ -36,16 +36,16 @@ data class OtherUserProfilesResponse(
     data class ProfileInfo(
         val profileId: String,
         val sportCode: String,
-        val isActive: Boolean,
+        val isSelected: Boolean,
     ) {
         companion object {
             fun from(
-                isActive: Boolean,
+                isSelected: Boolean,
                 u: UserSportProfile,
             ) = ProfileInfo(
                 profileId = u.id!!,
                 sportCode = u.sport.code,
-                isActive = isActive
+                isSelected = isSelected
             )
 
             fun listForm(
@@ -53,7 +53,7 @@ data class OtherUserProfilesResponse(
                 selectedSportProfileId: String,
             ) = allProfiles.map { userSportProfile ->
                 from(
-                    isActive = userSportProfile.id == selectedSportProfileId,
+                    isSelected = userSportProfile.id == selectedSportProfileId,
                     u = userSportProfile,
                 )
             }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfileTierResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfileTierResponse.kt
@@ -9,7 +9,7 @@ data class UserProfileTierResponse(
     data class ActiveProfile(
         val profileId: String,
         val sportCode: String,
-        val tierId: Int,
+        val tierId: Long,
         val lp: Int,
         val minLp: Int,
         val maxLp: Int,
@@ -22,7 +22,7 @@ data class UserProfileTierResponse(
             ) = ActiveProfile(
                 profileId = u.id!!,
                 sportCode = u.sport.code,
-                tierId = u.tier.orderNo,
+                tierId = u.tier.id!!,
                 lp = u.lp,
                 minLp = u.tier.minLp,
                 maxLp = u.tier.maxLp,

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfileTierResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfileTierResponse.kt
@@ -49,10 +49,10 @@ data class UserProfileTierResponse(
 
             fun listForm(
                 allProfiles: List<UserSportProfile>,
-                activeSportProfileId: String,
+                activeProfileId: String,
             ) = allProfiles.map { userSportProfile ->
                 from(
-                    isActive = userSportProfile.id == activeSportProfileId,
+                    isActive = userSportProfile.id == activeProfileId,
                     u = userSportProfile
                 )
             }
@@ -67,9 +67,8 @@ data class UserProfileTierResponse(
             activeProfile = ActiveProfile.from(activeProfile),
             allProfiles = ProfileInfo.listForm(
                 allProfiles = allProfiles,
-                activeSportProfileId = activeProfile.id!!
+                activeProfileId = activeProfile.id!!
             )
-
         )
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfileTierResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfileTierResponse.kt
@@ -1,10 +1,12 @@
 package org.appjam.smashing.domain.user.dto.response
 
+import org.appjam.smashing.domain.user.entity.UserSportProfile
+
 data class UserProfileTierResponse(
-    val activeSport: ActiveSport,
-    val sports: List<SportInfo>,
+    val activeProfile: ActiveProfile,
+    val allProfiles: List<ProfileInfo>,
 ) {
-    data class ActiveSport(
+    data class ActiveProfile(
         val profileId: String,
         val sportCode: String,
         val tierId: Int,
@@ -16,39 +18,58 @@ data class UserProfileTierResponse(
     ) {
         companion object {
             fun from(
-                profileId: String,
-                sportCode: String,
-                tierId: Int,
-                lp: Int,
-                minLp: Int,
-                maxLp: Int,
-                wins: Int,
-                losses: Int,
-            ) = ActiveSport(
-                profileId = profileId,
-                sportCode = sportCode,
-                tierId = tierId,
-                lp = lp,
-                minLp = minLp,
-                maxLp = maxLp,
-                wins = wins,
-                losses = losses,
+                u: UserSportProfile
+            ) = ActiveProfile(
+                profileId = u.id!!,
+                sportCode = u.sport.code,
+                tierId = u.tier.orderNo,
+                lp = u.lp,
+                minLp = u.tier.minLp,
+                maxLp = u.tier.maxLp,
+                wins = u.wins,
+                losses = u.losses,
             )
         }
     }
 
-    data class SportInfo(
+    data class ProfileInfo(
         val profileId: String,
         val sportCode: String,
+        val isActive: Boolean
     ) {
         companion object {
             fun from(
-                profileId: String,
-                sportCode: String,
-            ) = SportInfo(
-                profileId = profileId,
-                sportCode = sportCode,
+                isActive: Boolean,
+                u: UserSportProfile
+            ) = ProfileInfo(
+                profileId = u.id!!,
+                sportCode = u.sport.code,
+                isActive = isActive,
             )
+
+            fun listForm(
+                allProfiles: List<UserSportProfile>,
+                activeSportProfileId: String,
+            ) = allProfiles.map { userSportProfile ->
+                from(
+                    isActive = userSportProfile.id == activeSportProfileId,
+                    u = userSportProfile
+                )
+            }
         }
+    }
+
+    companion object {
+        fun from(
+            activeProfile: UserSportProfile,
+            allProfiles: List<UserSportProfile>
+        ) = UserProfileTierResponse(
+            activeProfile = ActiveProfile.from(activeProfile),
+            allProfiles = ProfileInfo.listForm(
+                allProfiles = allProfiles,
+                activeSportProfileId = activeProfile.id!!
+            )
+
+        )
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfilesResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfilesResponse.kt
@@ -1,5 +1,7 @@
 package org.appjam.smashing.domain.user.dto.response
 
+import org.appjam.smashing.domain.user.entity.UserSportProfile
+
 data class UserProfilesResponse(
     val nickname: String,
     val activeSport: ActiveSport,
@@ -15,13 +17,58 @@ data class UserProfilesResponse(
         val wins: Int,
         val losses: Int,
     ) {
-
+        companion object {
+            fun from(
+                u: UserSportProfile,
+            ) = ActiveSport(
+                profileId = u.id!!,
+                sportCode = u.sport.code,
+                tierId = u.tier.orderNo,
+                lp = u.lp,
+                minLp = u.tier.minLp,
+                maxLp = u.tier.minLp,
+                wins = u.wins,
+                losses = u.losses,
+            )
+        }
     }
 
     data class SportInfo(
         val profileId: String,
         val sportCode: String,
     ) {
+        companion object {
+            fun from(
+                u: UserSportProfile,
+            ) = SportInfo(
+                profileId = u.id!!,
+                sportCode = u.sport.code,
+            )
 
+            fun listForm(
+                allProfiles: List<UserSportProfile>,
+                activeSportProfileId: String,
+            ) = allProfiles
+                .filter { userSportProfile ->
+                    userSportProfile.id != activeSportProfileId
+                }.map { userSportProfile ->
+                    from(userSportProfile)
+                }
+        }
+    }
+
+    companion object {
+        fun from(
+            nickname: String,
+            activeSport: UserSportProfile,
+            allProfiles: List<UserSportProfile>
+        ) = UserProfilesResponse(
+            nickname = nickname,
+            activeSport = ActiveSport.from(activeSport),
+            sports = SportInfo.listForm(
+                allProfiles = allProfiles,
+                activeSportProfileId = activeSport.id!!
+            )
+        )
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfilesResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfilesResponse.kt
@@ -4,10 +4,10 @@ import org.appjam.smashing.domain.user.entity.UserSportProfile
 
 data class UserProfilesResponse(
     val nickname: String,
-    val activeSport: ActiveSport,
-    val sports: List<SportInfo>,
+    val activeProfile: ActiveProfile,
+    val allProfiles: List<ProfileInfo>,
 ) {
-    data class ActiveSport(
+    data class ActiveProfile(
         val profileId: String,
         val sportCode: String,
         val tierId: Int,
@@ -20,7 +20,7 @@ data class UserProfilesResponse(
         companion object {
             fun from(
                 u: UserSportProfile,
-            ) = ActiveSport(
+            ) = ActiveProfile(
                 profileId = u.id!!,
                 sportCode = u.sport.code,
                 tierId = u.tier.orderNo,
@@ -33,41 +33,44 @@ data class UserProfilesResponse(
         }
     }
 
-    data class SportInfo(
+    data class ProfileInfo(
         val profileId: String,
         val sportCode: String,
+        val isActive: Boolean,
     ) {
         companion object {
             fun from(
+                isActive: Boolean,
                 u: UserSportProfile,
-            ) = SportInfo(
+            ) = ProfileInfo(
                 profileId = u.id!!,
                 sportCode = u.sport.code,
+                isActive = isActive,
             )
 
             fun listForm(
                 allProfiles: List<UserSportProfile>,
                 activeSportProfileId: String,
-            ) = allProfiles
-                .filter { userSportProfile ->
-                    userSportProfile.id != activeSportProfileId
-                }.map { userSportProfile ->
-                    from(userSportProfile)
-                }
+            ) = allProfiles.map { userSportProfile ->
+                from(
+                    isActive = userSportProfile.id == activeSportProfileId,
+                    u = userSportProfile
+                )
+            }
         }
     }
 
     companion object {
         fun from(
             nickname: String,
-            activeSport: UserSportProfile,
+            activeProfile: UserSportProfile,
             allProfiles: List<UserSportProfile>
         ) = UserProfilesResponse(
             nickname = nickname,
-            activeSport = ActiveSport.from(activeSport),
-            sports = SportInfo.listForm(
+            activeProfile = ActiveProfile.from(activeProfile),
+            allProfiles = ProfileInfo.listForm(
                 allProfiles = allProfiles,
-                activeSportProfileId = activeSport.id!!
+                activeSportProfileId = activeProfile.id!!,
             )
         )
     }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfilesResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfilesResponse.kt
@@ -26,7 +26,7 @@ data class UserProfilesResponse(
                 tierId = u.tier.orderNo,
                 lp = u.lp,
                 minLp = u.tier.minLp,
-                maxLp = u.tier.minLp,
+                maxLp = u.tier.maxLp,
                 wins = u.wins,
                 losses = u.losses,
             )

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfilesResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfilesResponse.kt
@@ -50,10 +50,10 @@ data class UserProfilesResponse(
 
             fun listForm(
                 allProfiles: List<UserSportProfile>,
-                activeSportProfileId: String,
+                activeProfileId: String,
             ) = allProfiles.map { userSportProfile ->
                 from(
-                    isActive = userSportProfile.id == activeSportProfileId,
+                    isActive = userSportProfile.id == activeProfileId,
                     u = userSportProfile
                 )
             }
@@ -70,7 +70,7 @@ data class UserProfilesResponse(
             activeProfile = ActiveProfile.from(activeProfile),
             allProfiles = ProfileInfo.listForm(
                 allProfiles = allProfiles,
-                activeSportProfileId = activeProfile.id!!,
+                activeProfileId = activeProfile.id!!,
             )
         )
     }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfilesResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfilesResponse.kt
@@ -10,7 +10,7 @@ data class UserProfilesResponse(
     data class ActiveProfile(
         val profileId: String,
         val sportCode: String,
-        val tierId: Int,
+        val tierId: Long,
         val lp: Int,
         val minLp: Int,
         val maxLp: Int,
@@ -23,7 +23,7 @@ data class UserProfilesResponse(
             ) = ActiveProfile(
                 profileId = u.id!!,
                 sportCode = u.sport.code,
-                tierId = u.tier.orderNo,
+                tierId = u.tier.id!!,
                 lp = u.lp,
                 minLp = u.tier.minLp,
                 maxLp = u.tier.maxLp,

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfilesResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/UserProfilesResponse.kt
@@ -1,0 +1,27 @@
+package org.appjam.smashing.domain.user.dto.response
+
+data class UserProfilesResponse(
+    val nickname: String,
+    val activeSport: ActiveSport,
+    val sports: List<SportInfo>,
+) {
+    data class ActiveSport(
+        val profileId: String,
+        val sportCode: String,
+        val tierId: Int,
+        val lp: Int,
+        val minLp: Int,
+        val maxLp: Int,
+        val wins: Int,
+        val losses: Int,
+    ) {
+
+    }
+
+    data class SportInfo(
+        val profileId: String,
+        val sportCode: String,
+    ) {
+
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
@@ -91,7 +91,7 @@ interface UserSportProfileRepository : JpaRepository<UserSportProfile, String> {
             order by s.name asc
         """
     )
-    fun findAllByUserId(
+    fun findAllByUserIdOrderByName(
         userId: String,
     ): List<UserSportProfile>
 

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -77,32 +77,14 @@ class UserService(
         val user = userRepository.findByIdOrNull(userId)
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
-        val allProfiles = userSportProfileRepository.findAllByUserId(userId)
+        val allProfiles = userSportProfileRepository.findAllByUserIdOrderByName(userId)
 
         val activeProfile = allProfiles.find { it.id == user.activeUserSportProfileId }
             ?: throw CustomException(ErrorCode.ACTIVE_PROFILE_NOT_FOUND)
 
-        val sportsList = allProfiles
-            .filter { it.id != user.activeUserSportProfileId }
-            .map {
-                UserProfileTierResponse.SportInfo.from(
-                    profileId = it.id!!,
-                    sportCode = it.sport.code
-                )
-            }
-
-        return UserProfileTierResponse(
-            activeSport = UserProfileTierResponse.ActiveSport.from(
-                profileId = activeProfile.id!!,
-                sportCode = activeProfile.sport.code,
-                tierId = activeProfile.tier.orderNo,
-                lp = activeProfile.lp,
-                minLp = activeProfile.tier.minLp,
-                maxLp = activeProfile.tier.maxLp,
-                wins = activeProfile.wins,
-                losses = activeProfile.losses
-            ),
-            sports = sportsList
+        return UserProfileTierResponse.from(
+            activeProfile = activeProfile,
+            allProfiles = allProfiles,
         )
     }
 
@@ -152,14 +134,14 @@ class UserService(
         val user = userRepository.findByIdOrNull(userId)
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
-        val allProfiles = userSportProfileRepository.findAllByUserId(userId)
+        val allProfiles = userSportProfileRepository.findAllByUserIdOrderByName(userId)
 
         val activeSport = allProfiles.find { it.id == user.activeUserSportProfileId }
             ?: throw CustomException(ErrorCode.ACTIVE_PROFILE_NOT_FOUND)
 
         return UserProfilesResponse.from(
             nickname = user.nickname,
-            activeSport = activeSport,
+            activeProfile = activeSport,
             allProfiles = allProfiles,
         )
     }
@@ -172,7 +154,7 @@ class UserService(
         val otherUser = userRepository.findByIdOrNull(otherUserId)
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
-        val allProfiles = userSportProfileRepository.findAllByUserId(otherUserId)
+        val allProfiles = userSportProfileRepository.findAllByUserIdOrderByName(otherUserId)
 
         val selectedSport = if (sportCode == null) {
             allProfiles.find { it.id == otherUser.activeUserSportProfileId }
@@ -184,7 +166,7 @@ class UserService(
 
         return OtherUserProfilesResponse.from(
             nickname = otherUser.nickname,
-            selectedSport = selectedSport,
+            selectedProfile = selectedSport,
             allProfiles = allProfiles
         )
     }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -145,9 +145,23 @@ class UserService(
         }
     }
 
-    @Transactional
-    fun getUserProfiles(): UserProfilesResponse {
+    @Transactional(readOnly = true)
+    fun getUserProfiles(
+        userId: String,
+    ): UserProfilesResponse {
+        val user = userRepository.findByIdOrNull(userId)
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
+        val allProfiles = userSportProfileRepository.findAllByUserId(userId)
+
+        val activeSport = allProfiles.find { it.id == user.id }
+            ?: throw CustomException(ErrorCode.ACTIVE_PROFILE_NOT_FOUND)
+
+        return UserProfilesResponse.from(
+            nickname = user.nickname,
+            activeSport = activeSport,
+            allProfiles = allProfiles,
+        )
     }
 
     @Transactional(readOnly = true)

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -154,7 +154,7 @@ class UserService(
 
         val allProfiles = userSportProfileRepository.findAllByUserId(userId)
 
-        val activeSport = allProfiles.find { it.id == user.id }
+        val activeSport = allProfiles.find { it.id == user.activeUserSportProfileId }
             ?: throw CustomException(ErrorCode.ACTIVE_PROFILE_NOT_FOUND)
 
         return UserProfilesResponse.from(

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -136,12 +136,12 @@ class UserService(
 
         val allProfiles = userSportProfileRepository.findAllByUserIdOrderByName(userId)
 
-        val activeSport = allProfiles.find { it.id == user.activeUserSportProfileId }
+        val activeProfile = allProfiles.find { it.id == user.activeUserSportProfileId }
             ?: throw CustomException(ErrorCode.ACTIVE_PROFILE_NOT_FOUND)
 
         return UserProfilesResponse.from(
             nickname = user.nickname,
-            activeProfile = activeSport,
+            activeProfile = activeProfile,
             allProfiles = allProfiles,
         )
     }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -7,10 +7,7 @@ import org.appjam.smashing.domain.user.dto.command.ActiveProfileUpdateCommand
 import org.appjam.smashing.domain.user.dto.command.AddressUpdateCommand
 import org.appjam.smashing.domain.user.dto.command.OpenChatValidateCommand
 import org.appjam.smashing.domain.user.dto.command.ProfileAddCommand
-import org.appjam.smashing.domain.user.dto.response.NicknameCheckResponse
-import org.appjam.smashing.domain.user.dto.response.OpenChatValidateResponse
-import org.appjam.smashing.domain.user.dto.response.OtherUserProfilesResponse
-import org.appjam.smashing.domain.user.dto.response.UserProfileTierResponse
+import org.appjam.smashing.domain.user.dto.response.*
 import org.appjam.smashing.domain.user.entity.UserSportProfile
 import org.appjam.smashing.domain.user.repository.UserRepository
 import org.appjam.smashing.domain.user.repository.UserSportProfileRepository
@@ -146,6 +143,11 @@ class UserService(
         if (userSportProfileRepository.existsByUserIdAndSportId(userId, sportId)) {
             throw CustomException(ErrorCode.ALREADY_EXIST_SPORT_PROFILE)
         }
+    }
+
+    @Transactional
+    fun getUserProfiles(): UserProfilesResponse {
+
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #43

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 사용자 프로필별 마이페이지 정보 조회 API 

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 사용자 프로필별 마이페이지 정보 조회 API 구현

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 200 Ok
<img width="484" height="530" alt="image" src="https://github.com/user-attachments/assets/114ffe20-6634-48f9-8f62-775e7c6e4d02" />


## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 내용