### PR TITLE
[FEAT] 사용자 지역 유저들 실력순 조회 API 구현

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -132,9 +132,9 @@ class UserController(
 
     @GetMapping("/me/regions/leaderboard")
     fun getOtherUsersLeaderBoard(
-        @RequestHeader("userId") userId: String, // TODO: 인증/인가 회복시 @AuthenticationPrincipal 으로 변경
+        @AuthenticationPrincipal principal: CustomUserDetails,
     ): ResponseEntity<ApiResponse<OtherUsersLeaderBoardResponse>> {
-        val response = userService.getOtherUsersLeaderBoard(userId)
+        val response = userService.getOtherUsersLeaderBoard(principal.username)
 
         return ApiResponse.success(
             data = response

--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -128,8 +128,14 @@ class UserController(
         )
     }
 
-    @GetMapping("")
-    fun getOtherUsersLeaderBoard() {
+    @GetMapping("/me/regions/leaderboard")
+    fun getOtherUsersLeaderBoard(
+        @RequestHeader("userId") userId: String, // TODO: 인증/인가 회복시 @AuthenticationPrincipal 으로 변경
+    ): ResponseEntity<ApiResponse<OtherUsersLeaderBoardResponse>> {
+        val response = userService.getOtherUsersLeaderBoard(userId)
 
+        return ApiResponse.success(
+            data = response
+        )
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -127,4 +127,9 @@ class UserController(
             data = response,
         )
     }
+
+    @GetMapping("")
+    fun getOtherUsersLeaderBoard() {
+
+    }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUsersLeaderBoardResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUsersLeaderBoardResponse.kt
@@ -1,9 +1,45 @@
 package org.appjam.smashing.domain.user.dto.response
 
+import org.appjam.smashing.domain.user.entity.UserSportProfile
+
 data class OtherUsersLeaderBoardResponse(
-    val rank: Int,
-    val userId: String,
-    val nickname: String,
-    val tierId: Long,
-    val lp: Int,
-)
+    val topUsers: List<OtherUsers>,
+) {
+    data class OtherUsers(
+        val rank: Int,
+        val userId: String,
+        val nickname: String,
+        val tierId: Long,
+        val lp: Int,
+    ) {
+        companion object {
+            fun from(
+                u: UserSportProfile,
+                rank: Int,
+            ) = OtherUsers(
+                rank = rank,
+                userId = u.user.id!!,
+                nickname = u.user.nickname,
+                tierId = u.tier.id!!,
+                lp = u.lp,
+            )
+
+            fun listForm(
+                profiles: List<UserSportProfile>
+            ) = profiles.mapIndexed { index, profile ->
+                from(
+                    u = profile,
+                    rank = index + 1
+                )
+            }
+        }
+    }
+
+    companion object {
+        fun from(
+            topUsers: List<UserSportProfile>
+        ) = OtherUsersLeaderBoardResponse(
+            topUsers = OtherUsers.listForm(topUsers),
+        )
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUsersLeaderBoardResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUsersLeaderBoardResponse.kt
@@ -1,0 +1,9 @@
+package org.appjam.smashing.domain.user.dto.response
+
+data class OtherUsersLeaderBoardResponse(
+    val rank: Int,
+    val userId: String,
+    val nickname: String,
+    val tierId: Long,
+    val lp: Int,
+)

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
@@ -123,7 +123,26 @@ interface UserSportProfileRepository : JpaRepository<UserSportProfile, String> {
             order by u.id asc
         """
     )
-    fun findAllByRegionAndSport(
+    fun findAllByRegionAndSportOrderByUserId(
+        region: String,
+        sportId: Long,
+        excludeUserId: String
+    ): List<UserSportProfile>
+
+    @Query(
+        """
+            select usp
+            from UserSportProfile usp
+            join fetch usp.user u
+            join fetch usp.sport s
+            join fetch usp.tier t
+            where u.region = :region
+              and s.id = :sportId
+              and u.id <> :excludeUserId
+            order by usp.lp desc
+        """
+    )
+    fun findAllByRegionAndSportOrderByLp(
         region: String,
         sportId: Long,
         excludeUserId: String

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
@@ -139,7 +139,8 @@ interface UserSportProfileRepository : JpaRepository<UserSportProfile, String> {
             where u.region = :region
               and s.id = :sportId
               and u.id <> :excludeUserId
-            order by usp.lp desc
+            order by usp.lp desc, u.nickname asc 
+            limit 30
         """
     )
     fun findAllByRegionAndSportOrderByLp(

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -207,7 +207,7 @@ class UserService(
     ): OtherUsersRecommendationResponse {
         val (user, activeProfile) = getMyInfoAndActiveProfile(userId)
 
-        val allRecommendProfiles = userSportProfileRepository.findAllByRegionAndSport(
+        val allRecommendProfiles = userSportProfileRepository.findAllByRegionAndSportOrderByUserId(
             region = user.region,
             sportId = activeProfile.sport.id!!,
             excludeUserId = user.id!!
@@ -266,11 +266,29 @@ class UserService(
         }
     }
 
+    @Transactional(readOnly = true)
+    fun getOtherUsersLeaderBoard(
+        userId: String,
+    ): OtherUsersLeaderBoardResponse {
+        val (user, activeProfile) = getMyInfoAndActiveProfile(userId)
+
+        val leaderBoardProfiles = userSportProfileRepository.findAllByRegionAndSportOrderByLp(
+            region = user.region,
+            sportId = activeProfile.sport.id!!,
+            excludeUserId = user.id!!
+        ).take(MAX_LEADERBOARD)
+
+        return OtherUsersLeaderBoardResponse.from(
+            topUsers = leaderBoardProfiles
+        )
+    }
+
     companion object {
         private val NICKNAME_VALID_REGEX = Regex("^[a-zA-Z0-9가-힣]*$")
         private const val MAX_NICKNAME_LENGTH = 10
         val OPEN_CHAT_URL_REGEX = Regex("^https://open\\.kakao\\.com/o/[a-zA-Z0-9]+\$")
         private const val MAX_SHUFFLE_LP = 200
         private const val MAX_LP_GAP = 5
+        private const val MAX_LEADERBOARD = 30
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -276,7 +276,7 @@ class UserService(
             region = user.region,
             sportId = activeProfile.sport.id!!,
             excludeUserId = user.id!!
-        ).take(MAX_LEADERBOARD)
+        )
 
         return OtherUsersLeaderBoardResponse.from(
             topUsers = leaderBoardProfiles
@@ -289,6 +289,5 @@ class UserService(
         val OPEN_CHAT_URL_REGEX = Regex("^https://open\\.kakao\\.com/o/[a-zA-Z0-9]+\$")
         private const val MAX_SHUFFLE_LP = 200
         private const val MAX_LP_GAP = 5
-        private const val MAX_LEADERBOARD = 30
     }
 }


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #55

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 사용자 지역 유저들 실력순 조회 API 
  - 사용자와 사용자의 활성 프로필을 가져옵니다.
  - 그리고 지역과 스포츠가 같은 모든 유저를 불러와 LP 순으로 정렬합니다. 
  - 그 후, 상위 30만 `take()`했습니다. 

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 사용자 지역 유저들 실력순 조회 API 

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 200 Ok
<img width="524" height="485" alt="image" src="https://github.com/user-attachments/assets/fca6737e-4360-4fb2-b62f-b2d400e8421b" />


## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 내용