### PR TITLE
[FEAT] 유저 닉네임 기준 목록 검색 API 구현

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -141,7 +141,7 @@ class UserController(
         )
     }
 
-    @GetMapping("")
+    @GetMapping("/search")
     fun getOtherUserSearch(
         @AuthenticationPrincipal principal: CustomUserDetails,
         @RequestParam("nickname") nickname: String,

--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -141,11 +141,11 @@ class UserController(
     @GetMapping("/search")
     fun getOtherUserSearch(
         @AuthenticationPrincipal principal: CustomUserDetails,
-        @Valid @RequestParam("nickname") requestCommand: OtherUserSearchRequest,
+        @Valid request: OtherUserSearchRequest,
     ): ResponseEntity<ApiResponse<OtherUserSearchResponse>> {
         val response = userService.getOtherUserSearch(
             userId = principal.username,
-            requestCommand = requestCommand.toCommand(),
+            requestCommand = request.toCommand(),
         )
 
         return ApiResponse.success(

--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -1,6 +1,7 @@
 package org.appjam.smashing.domain.user.controller
 
 import jakarta.validation.Valid
+import org.appjam.smashing.domain.user.dto.command.OtherUserSearchCommand
 import org.appjam.smashing.domain.user.dto.request.ActiveProfileUpdateRequest
 import org.appjam.smashing.domain.user.dto.request.AddressUpdateRequest
 import org.appjam.smashing.domain.user.dto.request.OpenChatValidateRequest
@@ -144,11 +145,11 @@ class UserController(
     @GetMapping("/search")
     fun getOtherUserSearch(
         @AuthenticationPrincipal principal: CustomUserDetails,
-        @RequestParam("nickname") nickname: String,
+        @Valid @RequestParam("nickname") requestCommand: OtherUserSearchCommand,
     ): ResponseEntity<ApiResponse<OtherUserSearchResponse>> {
         val response = userService.getOtherUserSearch(
             userId = principal.username,
-            nickname = nickname,
+            nickname = requestCommand.nickname,
         )
 
         return ApiResponse.success(

--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -1,11 +1,7 @@
 package org.appjam.smashing.domain.user.controller
 
 import jakarta.validation.Valid
-import org.appjam.smashing.domain.user.dto.command.OtherUserSearchCommand
-import org.appjam.smashing.domain.user.dto.request.ActiveProfileUpdateRequest
-import org.appjam.smashing.domain.user.dto.request.AddressUpdateRequest
-import org.appjam.smashing.domain.user.dto.request.OpenChatValidateRequest
-import org.appjam.smashing.domain.user.dto.request.ProfileAddRequest
+import org.appjam.smashing.domain.user.dto.request.*
 import org.appjam.smashing.domain.user.dto.response.*
 import org.appjam.smashing.domain.user.service.UserService
 import org.appjam.smashing.global.auth.security.data.CustomUserDetails
@@ -145,11 +141,11 @@ class UserController(
     @GetMapping("/search")
     fun getOtherUserSearch(
         @AuthenticationPrincipal principal: CustomUserDetails,
-        @Valid @RequestParam("nickname") requestCommand: OtherUserSearchCommand,
+        @Valid @RequestParam("nickname") requestCommand: OtherUserSearchRequest,
     ): ResponseEntity<ApiResponse<OtherUserSearchResponse>> {
         val response = userService.getOtherUserSearch(
             userId = principal.username,
-            nickname = requestCommand.nickname,
+            requestCommand = requestCommand.toCommand(),
         )
 
         return ApiResponse.success(

--- a/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/controller/UserController.kt
@@ -140,4 +140,19 @@ class UserController(
             data = response
         )
     }
+
+    @GetMapping("")
+    fun getOtherUserSearch(
+        @AuthenticationPrincipal principal: CustomUserDetails,
+        @RequestParam("nickname") nickname: String,
+    ): ResponseEntity<ApiResponse<OtherUserSearchResponse>> {
+        val response = userService.getOtherUserSearch(
+            userId = principal.username,
+            nickname = nickname,
+        )
+
+        return ApiResponse.success(
+            data = response,
+        )
+    }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/command/OtherUserSearchCommand.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/command/OtherUserSearchCommand.kt
@@ -1,0 +1,5 @@
+package org.appjam.smashing.domain.user.dto.command
+
+data class OtherUserSearchCommand(
+    val nickname: String,
+)

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/projection/OtherUserSearchProjection.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/projection/OtherUserSearchProjection.kt
@@ -1,0 +1,9 @@
+package org.appjam.smashing.domain.user.dto.projection
+
+import com.querydsl.core.annotations.QueryProjection
+
+@QueryProjection
+data class OtherUserSearchProjection(
+    val userId: String,
+    val nickname: String,
+)

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/request/OtherUserSearchRequest.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/request/OtherUserSearchRequest.kt
@@ -1,0 +1,13 @@
+package org.appjam.smashing.domain.user.dto.request
+
+import jakarta.validation.constraints.Size
+import org.appjam.smashing.domain.user.dto.command.OtherUserSearchCommand
+
+data class OtherUserSearchRequest(
+    @field:Size(max = 10, message = "nickname은 10자 이하입니다.")
+    val nickname: String?
+) {
+    fun toCommand() = OtherUserSearchCommand(
+        nickname = nickname!!,
+    )
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/request/OtherUserSearchRequest.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/request/OtherUserSearchRequest.kt
@@ -1,9 +1,11 @@
 package org.appjam.smashing.domain.user.dto.request
 
+import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 import org.appjam.smashing.domain.user.dto.command.OtherUserSearchCommand
 
 data class OtherUserSearchRequest(
+    @field:NotBlank(message = "nickname을 입력해주세요.")
     @field:Size(max = 10, message = "nickname은 10자 이하입니다.")
     val nickname: String?
 ) {

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUserSearchResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUserSearchResponse.kt
@@ -1,10 +1,39 @@
 package org.appjam.smashing.domain.user.dto.response
 
+import org.appjam.smashing.domain.user.entity.UserSportProfile
+
 data class OtherUserSearchResponse(
-    val users: SearchUser
+    val users: List<SearchUser>,
 ) {
     data class SearchUser(
         val userId: String,
         val nickname: String,
-    )
+    ) {
+        companion object {
+            fun from(
+                userId: String,
+                nickname: String,
+            ) = SearchUser(
+                userId = userId,
+                nickname = nickname,
+            )
+
+            fun listForm(
+                users: List<UserSportProfile>
+            ) = users.map { user ->
+                from(
+                    userId = user.id!!,
+                    nickname = user.user.nickname,
+                )
+            }
+        }
+    }
+
+    companion object {
+        fun from(
+            users: List<UserSportProfile>,
+        ) = OtherUserSearchResponse(
+            users = SearchUser.listForm(users)
+        )
+    }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUserSearchResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUserSearchResponse.kt
@@ -1,0 +1,10 @@
+package org.appjam.smashing.domain.user.dto.response
+
+data class OtherUserSearchResponse(
+    val users: SearchUser
+) {
+    data class SearchUser(
+        val userId: String,
+        val nickname: String,
+    )
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUserSearchResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUserSearchResponse.kt
@@ -1,6 +1,6 @@
 package org.appjam.smashing.domain.user.dto.response
 
-import org.appjam.smashing.domain.user.entity.UserSportProfile
+import org.appjam.smashing.domain.user.dto.projection.OtherUserSearchProjection
 
 data class OtherUserSearchResponse(
     val users: List<SearchUser>,
@@ -19,11 +19,11 @@ data class OtherUserSearchResponse(
             )
 
             fun listForm(
-                users: List<UserSportProfile>
-            ) = users.map { user ->
+                users: List<OtherUserSearchProjection>
+            ) = users.map { otherUser ->
                 from(
-                    userId = user.id!!,
-                    nickname = user.user.nickname,
+                    userId = otherUser.userId,
+                    nickname = otherUser.nickname,
                 )
             }
         }
@@ -31,7 +31,7 @@ data class OtherUserSearchResponse(
 
     companion object {
         fun from(
-            users: List<UserSportProfile>,
+            users: List<OtherUserSearchProjection>,
         ) = OtherUserSearchResponse(
             users = SearchUser.listForm(users)
         )

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
@@ -123,17 +123,15 @@ interface UserSportProfileRepository : JpaRepository<UserSportProfile, String>, 
             from UserSportProfile usp
             join fetch usp.user u
             join fetch usp.sport s
-            where u.region = :region 
-            and s.id = :sportId
+            where s.id = :sportId
             and u.id <> :excludeUserId
             and u.nickname like :nickname%
             order by u.nickname
             limit 5
         """
     )
-    fun findAllByRegionAndSportOrderByNickname(
+    fun findAllBySportOrderByNickname(
         nickname: String,
-        region: String,
         sportId: Long,
         excludeUserId: String,
     ): List<UserSportProfile>

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
@@ -91,7 +91,7 @@ interface UserSportProfileRepository : JpaRepository<UserSportProfile, String>, 
             order by s.name asc
         """
     )
-    fun findAllByUserIdOrderByName(
+    fun findAllByUserIdOrderBySportName(
         userId: String,
     ): List<UserSportProfile>
 
@@ -115,5 +115,24 @@ interface UserSportProfileRepository : JpaRepository<UserSportProfile, String>, 
         region: String,
         sportId: Long,
         excludeUserId: String
+    ): List<UserSportProfile>
+
+    @Query(
+        """
+            select usp
+            from UserSportProfile usp
+            join fetch usp.user u
+            join fetch usp.sport s
+            where u.region = :region 
+            and s.id = :sportId
+            and u.id <> :excludeUserId
+            order by u.nickname
+            limit 5
+        """
+    )
+    fun findAllByRegionAndSportOrderByNickname(
+        region: String,
+        sportId: Long,
+        excludeUserId: String,
     ): List<UserSportProfile>
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
@@ -116,23 +116,4 @@ interface UserSportProfileRepository : JpaRepository<UserSportProfile, String>, 
         sportId: Long,
         excludeUserId: String
     ): List<UserSportProfile>
-
-    @Query(
-        """
-            select usp
-            from UserSportProfile usp
-            join fetch usp.user u
-            join fetch usp.sport s
-            where s.id = :sportId
-            and u.id <> :excludeUserId
-            and u.nickname like :nickname%
-            order by u.nickname
-            limit 5
-        """
-    )
-    fun findAllBySportOrderByNickname(
-        nickname: String,
-        sportId: Long,
-        excludeUserId: String,
-    ): List<UserSportProfile>
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
@@ -126,11 +126,13 @@ interface UserSportProfileRepository : JpaRepository<UserSportProfile, String>, 
             where u.region = :region 
             and s.id = :sportId
             and u.id <> :excludeUserId
+            and u.nickname like :nickname%
             order by u.nickname
             limit 5
         """
     )
     fun findAllByRegionAndSportOrderByNickname(
+        nickname: String,
         region: String,
         sportId: Long,
         excludeUserId: String,

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepositoryCustom.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepositoryCustom.kt
@@ -1,6 +1,7 @@
 package org.appjam.smashing.domain.user.repository
 
 import org.appjam.smashing.domain.user.dto.projection.OtherUserRecommendationProjection
+import org.appjam.smashing.domain.user.dto.projection.OtherUserSearchProjection
 
 interface UserSportProfileRepositoryCustom {
     fun findRandomRecommendation(
@@ -11,4 +12,10 @@ interface UserSportProfileRepositoryCustom {
         lpThreshold: Int,
         limit: Long,
     ): List<OtherUserRecommendationProjection>
+
+    fun findAllBySportOrderByNickname(
+        nickname: String,
+        sportId: Long,
+        excludeUserId: String,
+    ): List<OtherUserSearchProjection>
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepositoryCustom.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepositoryCustom.kt
@@ -13,6 +13,24 @@ interface UserSportProfileRepositoryCustom {
         limit: Long,
     ): List<OtherUserRecommendationProjection>
 
+    /**
+     * nickname을 기준으로 조건에 맞는 유저를 반환합니다.
+     *
+     * [검색 및 필터 조건]
+     * 1) 입력한 nickname으로 시작하는 유저
+     * 2) 기준 유저의 활성화된 스포츠와 동일한 스포츠를 가진 유저
+     * 3) 지역 무관
+     * 4) 본인(excludeUserId) 제외
+     *
+     * [정렬 및 제한]
+     * - 닉네임 오름차순 정렬
+     * - 최대 5명까지 반환
+     *
+     * @param nickname 검색하고자 하는 닉네임
+     * @param sportId 유저의 활성화된 스포츠 아이디
+     * @param excludeUserId 제외하고자 하는 유저 (본인)
+     * @return 조건에 부합하는 다른 유저의 아이디와 닉네임
+     */
     fun findAllBySportOrderByNickname(
         nickname: String,
         sportId: Long,

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepositoryCustomImpl.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepositoryCustomImpl.kt
@@ -4,7 +4,9 @@ import com.querydsl.jpa.JPAExpressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.appjam.smashing.domain.review.entity.QGameReview
 import org.appjam.smashing.domain.user.dto.projection.OtherUserRecommendationProjection
+import org.appjam.smashing.domain.user.dto.projection.OtherUserSearchProjection
 import org.appjam.smashing.domain.user.dto.projection.QOtherUserRecommendationProjection
+import org.appjam.smashing.domain.user.dto.projection.QOtherUserSearchProjection
 import org.appjam.smashing.domain.user.entity.QUser.Companion.user
 import org.appjam.smashing.domain.user.entity.QUserSportProfile.Companion.userSportProfile
 import org.appjam.smashing.global.util.QueryUtils.randomOrder
@@ -52,4 +54,25 @@ class UserSportProfileRepositoryCustomImpl(
             .limit(limit)
             .fetch()
     }
+
+    override fun findAllBySportOrderByNickname(
+        nickname: String,
+        sportId: Long,
+        excludeUserId: String,
+    ): List<OtherUserSearchProjection> =
+        queryFactory
+            .select(
+                QOtherUserSearchProjection(
+                    user.id,
+                    user.nickname
+                )
+            ).from(userSportProfile)
+            .join(userSportProfile.user, user)
+            .where(
+                userSportProfile.sport.id.eq(sportId),
+                user.id.ne(excludeUserId),
+                user.nickname.startsWith(nickname)
+            )
+            .orderBy(user.nickname.asc())
+            .fetch()
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepositoryCustomImpl.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepositoryCustomImpl.kt
@@ -74,5 +74,6 @@ class UserSportProfileRepositoryCustomImpl(
                 user.nickname.startsWith(nickname)
             )
             .orderBy(user.nickname.asc())
+            .limit(5)
             .fetch()
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -244,6 +244,15 @@ class UserService(
         return user to activeProfile
     }
 
+    @Transactional(readOnly = true)
+    fun getOtherUserSearch(
+        userId: String,
+        nickname: String,
+    ): OtherUserSearchResponse {
+        
+
+    }
+
     companion object {
         private val NICKNAME_VALID_REGEX = Regex("^[a-zA-Z0-9가-힣]*$")
         private const val MAX_NICKNAME_LENGTH = 10

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -241,9 +241,8 @@ class UserService(
     ): OtherUserSearchResponse {
         val (user, activeProfile) = getMyInfoAndActiveProfile(userId)
 
-        val otherUsersSearch = userSportProfileRepository.findAllByRegionAndSportOrderByNickname(
+        val otherUsersSearch = userSportProfileRepository.findAllBySportOrderByNickname(
             nickname = nickname,
-            region = user.region,
             sportId = activeProfile.sport.id!!,
             excludeUserId = userId,
         )

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -78,7 +78,7 @@ class UserService(
         val user = userRepository.findByIdOrNull(userId)
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
-        val allProfiles = userSportProfileRepository.findAllByUserIdOrderByName(userId)
+        val allProfiles = userSportProfileRepository.findAllByUserIdOrderBySportName(userId)
 
         val activeProfile = allProfiles.find { it.id == user.activeUserSportProfileId }
             ?: throw CustomException(ErrorCode.ACTIVE_PROFILE_NOT_FOUND)
@@ -135,7 +135,7 @@ class UserService(
         val user = userRepository.findByIdOrNull(userId)
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
-        val allProfiles = userSportProfileRepository.findAllByUserIdOrderByName(userId)
+        val allProfiles = userSportProfileRepository.findAllByUserIdOrderBySportName(userId)
 
         val activeProfile = allProfiles.find { it.id == user.activeUserSportProfileId }
             ?: throw CustomException(ErrorCode.ACTIVE_PROFILE_NOT_FOUND)
@@ -155,7 +155,7 @@ class UserService(
         val otherUser = userRepository.findByIdOrNull(otherUserId)
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
-        val allProfiles = userSportProfileRepository.findAllByUserIdOrderByName(otherUserId)
+        val allProfiles = userSportProfileRepository.findAllByUserIdOrderBySportName(otherUserId)
 
         val selectedSport = if (sportCode == null) {
             allProfiles.find { it.id == otherUser.activeUserSportProfileId }
@@ -234,6 +234,22 @@ class UserService(
         )
     }
 
+    @Transactional(readOnly = true)
+    fun getOtherUserSearch(
+        userId: String,
+        nickname: String,
+    ): OtherUserSearchResponse {
+        val (user, activeProfile) = getMyInfoAndActiveProfile(userId)
+
+        val otherUsersSearch = userSportProfileRepository.findAllByRegionAndSportOrderByNickname(
+            region = user.region,
+            sportId = activeProfile.sport.id!!,
+            excludeUserId = userId,
+        )
+
+        return OtherUserSearchResponse.from(otherUsersSearch)
+    }
+
     private fun getMyInfoAndActiveProfile(userId: String): Pair<User, UserSportProfile> {
         val user = userRepository.findByIdOrNull(userId)
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
@@ -242,15 +258,6 @@ class UserService(
             ?: throw CustomException(ErrorCode.ACTIVE_PROFILE_NOT_FOUND)
 
         return user to activeProfile
-    }
-
-    @Transactional(readOnly = true)
-    fun getOtherUserSearch(
-        userId: String,
-        nickname: String,
-    ): OtherUserSearchResponse {
-        
-
     }
 
     companion object {

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -3,10 +3,7 @@ package org.appjam.smashing.domain.user.service
 import org.appjam.smashing.domain.sport.enums.InitTierLp
 import org.appjam.smashing.domain.sport.repository.SportRepository
 import org.appjam.smashing.domain.tier.repository.TierRepository
-import org.appjam.smashing.domain.user.dto.command.ActiveProfileUpdateCommand
-import org.appjam.smashing.domain.user.dto.command.AddressUpdateCommand
-import org.appjam.smashing.domain.user.dto.command.OpenChatValidateCommand
-import org.appjam.smashing.domain.user.dto.command.ProfileAddCommand
+import org.appjam.smashing.domain.user.dto.command.*
 import org.appjam.smashing.domain.user.dto.response.*
 import org.appjam.smashing.domain.user.entity.User
 import org.appjam.smashing.domain.user.entity.UserSportProfile
@@ -237,12 +234,12 @@ class UserService(
     @Transactional(readOnly = true)
     fun getOtherUserSearch(
         userId: String,
-        nickname: String,
+        requestCommand: OtherUserSearchCommand,
     ): OtherUserSearchResponse {
         val (user, activeProfile) = getMyInfoAndActiveProfile(userId)
 
         val otherUsersSearch = userSportProfileRepository.findAllBySportOrderByNickname(
-            nickname = nickname,
+            nickname = requestCommand.nickname,
             sportId = activeProfile.sport.id!!,
             excludeUserId = userId,
         )

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -242,6 +242,7 @@ class UserService(
         val (user, activeProfile) = getMyInfoAndActiveProfile(userId)
 
         val otherUsersSearch = userSportProfileRepository.findAllByRegionAndSportOrderByNickname(
+            nickname = nickname,
             region = user.region,
             sportId = activeProfile.sport.id!!,
             excludeUserId = userId,


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #42

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 유저 닉네임 기준 목록 검색 API 구현
  - 유저의 활성화된 스포츠가 같은 다른 유저들을 닉네임 기반으로 검색하는 API입니다.
  - findAllByRegionAndSportOrderByNickname를 통해 데이터를 추출했습니다.
  - 검색한 nickname의 경우 nickname의 뒷부분만 불러 와야 된다고 하여 `nickname&`으로 처리했습니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 유저 닉네임 기준 목록 검색 API 구현

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 200 Ok
- `nickname=사토루`
<img width="575" height="398" alt="image" src="https://github.com/user-attachments/assets/beb1e73a-bd1d-4097-87e3-032b1f863708" />


## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 내용