### PR TITLE
[CHORE] 후기 단건 상세 조회 API, 사용자 지역 유저들 실력순 조회 API 응답값 수정

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/domain/review/dto/response/ReviewDetailResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/review/dto/response/ReviewDetailResponse.kt
@@ -1,8 +1,10 @@
 package org.appjam.smashing.domain.review.dto.response
 
 import org.appjam.smashing.domain.review.entity.GameReview
+import org.appjam.smashing.domain.review.enums.ReviewRating
 
 data class ReviewDetailResponse(
+    val rating: ReviewRating,
     val reviewerNickname: String,
     val revieweeNickname: String,
     val tag: List<String>,
@@ -12,6 +14,7 @@ data class ReviewDetailResponse(
         fun from(
             gr: GameReview,
         ) = ReviewDetailResponse(
+            rating = gr.rating,
             reviewerNickname = gr.reviewer.nickname,
             revieweeNickname = gr.reviewee.nickname,
             tag = gr.tags.map { it.name },

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUsersLeaderBoardResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUsersLeaderBoardResponse.kt
@@ -4,6 +4,7 @@ import org.appjam.smashing.domain.user.entity.UserSportProfile
 
 data class OtherUsersLeaderBoardResponse(
     val topUsers: List<OtherUsers>,
+    val user: UserInfo,
 ) {
     data class OtherUsers(
         val rank: Int,
@@ -35,10 +36,36 @@ data class OtherUsersLeaderBoardResponse(
         }
     }
 
+    data class UserInfo(
+        val nickname: String,
+        val tierId: Long,
+        val lp: Int,
+    ) {
+        companion object {
+            fun from(
+                nickname: String,
+                tierId: Long,
+                lp: Int,
+            ) = UserInfo(
+                nickname = nickname,
+                tierId = tierId,
+                lp = lp,
+            )
+        }
+    }
+
     companion object {
         fun from(
-            topUsers: List<UserSportProfile>
+            topUsers: List<UserSportProfile>,
+            nickname: String,
+            tierId: Long,
+            lp: Int,
         ) = OtherUsersLeaderBoardResponse(
+            user = UserInfo.from(
+                nickname = nickname,
+                tierId = tierId,
+                lp = lp,
+            ),
             topUsers = OtherUsers.listForm(topUsers),
         )
     }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -234,7 +234,10 @@ class UserService(
         )
 
         return OtherUsersLeaderBoardResponse.from(
-            topUsers = leaderBoardProfiles
+            topUsers = leaderBoardProfiles,
+            nickname = user.nickname,
+            tierId = activeProfile.tier.id!!,
+            lp = activeProfile.lp,
         )
     }
 


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #98

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 후기 단건 상세 조회 API 응답값 수정
- 사용자 지역 유저들 실력순 조회 API 응답값 수정

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 후기 단건 상세 조회 API 응답값 수정
- [x] 사용자 지역 유저들 실력순 조회 API 응답값 수정

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 후기 단건 상세 조회 API
<img width="546" height="336" alt="image" src="https://github.com/user-attachments/assets/68956108-899c-431f-8b23-2e3364c5b86d" />

- 사용자 지역 유저들 실력순 조회 API
<img width="426" height="526" alt="image" src="https://github.com/user-attachments/assets/345a9e22-67a9-43a3-9e68-4dad480344e0" />

## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 내용