### PR TITLE
[REFAC] lp history 저장 로직 추가

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
@@ -14,6 +14,8 @@ import org.appjam.smashing.domain.game.enums.GameResultStatus
 import org.appjam.smashing.domain.game.enums.SubmissionStatus
 import org.appjam.smashing.domain.game.repository.GameRepository
 import org.appjam.smashing.domain.game.repository.GameResultSubmissionRepository
+import org.appjam.smashing.domain.lp.entity.LpHistory
+import org.appjam.smashing.domain.lp.repository.LpHistoryRepository
 import org.appjam.smashing.domain.notification.enums.NotificationType
 import org.appjam.smashing.domain.notification.service.NotificationService
 import org.appjam.smashing.domain.outbox.components.OutboxEventPublisher
@@ -50,6 +52,7 @@ class GameService(
     private val outboxEventPublisher: OutboxEventPublisher,
     private val gameReviewService: GameReviewService,
     private val userSportProfileRepository: UserSportProfileRepository,
+    private val lpHistoryRepository: LpHistoryRepository,
     private val tierRepository: TierRepository,
 ) {
 
@@ -231,12 +234,11 @@ class GameService(
             .findByUserIdAndSportIdForUpdate(submission.confirmer.id!!, sportId)
             ?: throw CustomException(ErrorCode.USER_SPORT_PROFILE_NOT_FOUND)
 
-        // 승자/패자 프로필 업데이트 (승리/패배 수 + LP + 티어)
-        // TODO: 추후 lp 기록 쌓이는 로직 추가 필요
+        // 승자/패자 프로필 업데이트 (승리/패배 수 + LP + 티어 + LP history)
         val winnerProfile = if (submission.winner.id == submission.submitter.id) submitterProfile else confirmerProfile
         val loserProfile = if (submission.loser.id == submission.submitter.id) submitterProfile else confirmerProfile
 
-        applyLpAndTierUpdate(winnerProfile, loserProfile, sportId)
+        applyLpAndTierUpdate(winnerProfile, loserProfile, sportId, game)
 
         // 게임 상태 변경 SSE 발행
         publishGameUpdated(
@@ -835,26 +837,55 @@ class GameService(
         winnerProfile: UserSportProfile,
         loserProfile: UserSportProfile,
         sportId: Long,
+        game: Game,
     ) {
         // 승/패 수 갱신
         winnerProfile.recordWin()
         loserProfile.recordLoss()
 
-        // 각자 이번 경기가 몇 번째 경기인지 계산 (업데이트 후 wins+losses 기준)
-        val winnerGameNo = (winnerProfile.wins + winnerProfile.losses)
-        val loserGameNo = (loserProfile.wins + loserProfile.losses)
+        // 이번 경기 기준 gameNo 계산 (업데이트 후 wins+losses 기준)
+        val winnerGameNo = winnerProfile.wins + winnerProfile.losses
+        val loserGameNo = loserProfile.wins + loserProfile.losses
 
-        // 구간별 lp 증감 계산
-        val winnerLpDelta = calcWinLpDelta(winnerGameNo)
-        val loserLpDelta = calcLoseLpDelta(loserGameNo)
+        // 이번 경기 LP 변화량 계산
+        val winnerDelta = calcWinLpDelta(winnerGameNo)
+        val loserDelta = calcLoseLpDelta(loserGameNo)
 
-        // lp 반영 (0 미만 방지)
-        winnerProfile.lp += winnerLpDelta
-        loserProfile.lp = (loserProfile.lp - loserLpDelta).coerceAtLeast(0)
+        // before/after 계산 (0 미만 방지 포함)
+        val winnerBefore = winnerProfile.lp
+        val loserBefore = loserProfile.lp
 
-        // lp 기준 tier 재계산/갱신
-        winnerProfile.changeTier(resolveTierOrThrow(sportId, winnerProfile.lp))
-        loserProfile.changeTier(resolveTierOrThrow(sportId, loserProfile.lp))
+        val winnerAfter = winnerBefore + winnerDelta
+        val loserAfter = (loserBefore - loserDelta).coerceAtLeast(0)
+
+        // 실제 LP 반영
+        winnerProfile.lp = winnerAfter
+        loserProfile.lp = loserAfter
+
+        // tier 재계산/갱신
+        winnerProfile.changeTier(resolveTierOrThrow(sportId, winnerAfter))
+        loserProfile.changeTier(resolveTierOrThrow(sportId, loserAfter))
+
+        // LP history 2건 저장 (승자/패자 각각 1건)
+        lpHistoryRepository.save(
+            LpHistory.create(
+                userSportProfile = winnerProfile,
+                game = game,
+                beforeLp = winnerBefore,
+                deltaLp = winnerDelta,
+                afterLp = winnerAfter,
+            )
+        )
+
+        lpHistoryRepository.save(
+            LpHistory.create(
+                userSportProfile = loserProfile,
+                game = game,
+                beforeLp = loserBefore,
+                deltaLp = -loserDelta,
+                afterLp = loserAfter,
+            )
+        )
     }
 
     private fun calcWinLpDelta(

--- a/src/main/kotlin/org/appjam/smashing/domain/lp/entity/LpHistory.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/lp/entity/LpHistory.kt
@@ -1,7 +1,16 @@
-package org.appjam.smashing.domain.matching.entity
+package org.appjam.smashing.domain.lp.entity
 
 import io.hypersistence.utils.hibernate.id.Tsid
-import jakarta.persistence.*
+import jakarta.persistence.Column
+import jakarta.persistence.ConstraintMode
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.ForeignKey
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
 import org.appjam.smashing.domain.common.entity.BaseEntity
 import org.appjam.smashing.domain.game.entity.Game
 import org.appjam.smashing.domain.user.entity.UserSportProfile
@@ -55,5 +64,21 @@ class LpHistory(
     )
     @Comment("경기 IDX")
     val game: Game,
-) : BaseEntity()
+) : BaseEntity() {
 
+    companion object {
+        fun create(
+            userSportProfile: UserSportProfile,
+            game: Game,
+            beforeLp: Int,
+            deltaLp: Int,
+            afterLp: Int,
+        )= LpHistory(
+                deltaLp = deltaLp,
+                beforeLp = beforeLp,
+                afterLp = afterLp,
+                userSportProfile = userSportProfile,
+                game = game,
+            )
+        }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/lp/repository/LpHistoryRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/lp/repository/LpHistoryRepository.kt
@@ -1,0 +1,6 @@
+package org.appjam.smashing.domain.lp.repository
+
+import org.appjam.smashing.domain.lp.entity.LpHistory
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface LpHistoryRepository : JpaRepository<LpHistory, String>


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #110 

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- lp 변동시 lphistory 가 저장되는 로직을 추가합니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] lphistory 저장 로직 추가 

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 
<img width="615" height="452" alt="image" src="https://github.com/user-attachments/assets/b2b73f04-ae41-44ec-aa63-683956c539b1" />
<img width="1174" height="143" alt="image" src="https://github.com/user-attachments/assets/93596ca5-9b77-4168-9cb2-33bc056830eb" />


## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 내용