### PR TITLE
[REFAC] 게임 목록 조회시 최근의 제출안 id와 제출 시도 no을 같이 내려주도록

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/domain/game/dto/projection/PendingResultAcceptedGameProjection.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/dto/projection/PendingResultAcceptedGameProjection.kt
@@ -20,7 +20,9 @@ data class PendingResultAcceptedGameProjection(
     val opponentNickname: String,
     val opponentOpenchatUrl: String?,
     val opponentGender: Gender,
-    val opponentTierCode: TierCode
+    val opponentTierCode: TierCode,
+    val latestSubmissionId: String?,
+    val latestAttemptNo: Int?,
 ) : CursorKey {
 
     override val cursorId: String

--- a/src/main/kotlin/org/appjam/smashing/domain/game/dto/response/PendingResultAcceptedGameSummaryResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/dto/response/PendingResultAcceptedGameSummaryResponse.kt
@@ -14,6 +14,8 @@ data class PendingResultAcceptedGameSummaryResponse(
     val submitAvailableAt: OffsetDateTime,
     val remainingSeconds: Long,
     val isSubmitLocked: Boolean,
+    val latestSubmissionId: String? = null,
+    val latestAttemptNo: Int?,
 ) {
 
     data class OpponentSummary(
@@ -44,6 +46,8 @@ data class PendingResultAcceptedGameSummaryResponse(
             submitAvailableAt = submitAvailableAt,
             remainingSeconds = remainingSeconds,
             isSubmitLocked = isSubmitLocked,
+            latestSubmissionId = projection.latestSubmissionId,
+            latestAttemptNo = projection.latestAttemptNo,
         )
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepositoryCustomImpl.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepositoryCustomImpl.kt
@@ -2,10 +2,12 @@ package org.appjam.smashing.domain.game.repository
 
 import com.querydsl.core.BooleanBuilder
 import com.querydsl.core.types.dsl.CaseBuilder
+import com.querydsl.jpa.JPAExpressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.appjam.smashing.domain.game.dto.projection.PendingResultAcceptedGameProjection
 import org.appjam.smashing.domain.game.dto.projection.QPendingResultAcceptedGameProjection
 import org.appjam.smashing.domain.game.entity.QGame.Companion.game
+import org.appjam.smashing.domain.game.entity.QGameResultSubmission
 import org.appjam.smashing.domain.game.enums.GameResultStatus
 import org.appjam.smashing.domain.matching.entity.QMatching.Companion.matching
 import org.appjam.smashing.domain.matching.enums.MatchingStatus
@@ -46,6 +48,9 @@ class GameRepositoryCustomImpl(
         val requesterTier = QTier("requesterTier")
         val receiverTier = QTier("receiverTier")
 
+        val submission = QGameResultSubmission("submission")
+        val submissionSub = QGameResultSubmission("submissionSub")
+
         val opponentIdExpr = CaseBuilder().`when`(matching.requester.id.eq(userId)).then(receiver.id)
             .otherwise(requester.id)
 
@@ -60,6 +65,10 @@ class GameRepositoryCustomImpl(
 
         val opponentTierCodeExpr = CaseBuilder().`when`(matching.requester.id.eq(userId)).then(receiverTier.code)
             .otherwise(requesterTier.code)
+
+        val latestAttemptNoSubQuery = JPAExpressions.select(submissionSub.attemptNo.max())
+            .from(submissionSub)
+            .where(submissionSub.game.id.eq(game.id))
 
         val where = BooleanBuilder().and(
                 matching.requester.id.eq(userId)
@@ -95,6 +104,8 @@ class GameRepositoryCustomImpl(
                     opponentOpenchatExpr,
                     opponentGenderExpr,
                     opponentTierCodeExpr,
+                    submission.id,
+                    submission.attemptNo,
                 )
             )
             .from(game)
@@ -111,7 +122,10 @@ class GameRepositoryCustomImpl(
                     .and(receiverProfile.sport.id.eq(sportId))
             )
             .join(receiverProfile.tier, receiverTier)
-
+            .leftJoin(submission).on(
+                submission.game.eq(game)
+                    .and(submission.attemptNo.eq(latestAttemptNoSubQuery))
+            )
             .where(where)
             .orderBy(CursorQueryUtils.orderBy(game.id, orderType))
             .limit((size + 1).toLong())


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #129 

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 게임 목록 조회시 최근의 제출안 id와 제출 시도 no을 같이 내려주도록

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 게임 목록 조회시 최근의 제출안 id와 제출 시도 no을 같이 내려주도록

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 
<img width="594" height="635" alt="image" src="https://github.com/user-attachments/assets/fa558c01-933b-426a-b402-3a95fe5b819b" />


## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 내용