### PR TITLE
[REFAC] 결과 확정 전 경기 목록 조회시 최근 제출안 제출자 id를 함께 제출하도록

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/domain/game/dto/projection/PendingResultAcceptedGameProjection.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/dto/projection/PendingResultAcceptedGameProjection.kt
@@ -23,6 +23,7 @@ data class PendingResultAcceptedGameProjection(
     val opponentTierCode: TierCode,
     val latestSubmissionId: String?,
     val latestAttemptNo: Int?,
+    val latestSubmitterId: String?,
 ) : CursorKey {
 
     override val cursorId: String

--- a/src/main/kotlin/org/appjam/smashing/domain/game/dto/response/PendingResultAcceptedGameSummaryResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/dto/response/PendingResultAcceptedGameSummaryResponse.kt
@@ -16,6 +16,7 @@ data class PendingResultAcceptedGameSummaryResponse(
     val isSubmitLocked: Boolean,
     val latestSubmissionId: String? = null,
     val latestAttemptNo: Int?,
+    val latestSubmitterId: String? = null,
 ) {
 
     data class OpponentSummary(
@@ -48,6 +49,7 @@ data class PendingResultAcceptedGameSummaryResponse(
             isSubmitLocked = isSubmitLocked,
             latestSubmissionId = projection.latestSubmissionId,
             latestAttemptNo = projection.latestAttemptNo,
+            latestSubmitterId = projection.latestSubmitterId
         )
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepositoryCustomImpl.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepositoryCustomImpl.kt
@@ -107,6 +107,7 @@ class GameRepositoryCustomImpl(
                     opponentTierCodeExpr,
                     submission.id,
                     submission.attemptNo,
+                    submission.submitter.id
                 )
             )
             .from(game)


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #133 

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 결과 확정 전 경기 목록 조회시 최근 제출안 제출자 id를 함께 제출하도록

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 결과 확정 전 경기 목록 조회시 최근 제출안 제출자 id를 함께 제출하도록

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 
<img width="411" height="566" alt="image" src="https://github.com/user-attachments/assets/777eb9b8-db42-4f9a-a27c-438288eb69e1" />


## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 내용