### PR TITLE
[REFAC] 결과 반려 API 수정

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/domain/game/dto/command/GameResultRejectCommand.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/dto/command/GameResultRejectCommand.kt
@@ -3,5 +3,5 @@ package org.appjam.smashing.domain.game.dto.command
 import org.appjam.smashing.domain.game.enums.GameResultRejectReason
 
 data class GameResultRejectCommand(
-    val reason: GameResultRejectReason,
+    val reason: GameResultRejectReason?,
 )

--- a/src/main/kotlin/org/appjam/smashing/domain/game/dto/request/GameResultRejectRequest.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/dto/request/GameResultRejectRequest.kt
@@ -1,17 +1,15 @@
 package org.appjam.smashing.domain.game.dto.request
 
-import jakarta.validation.constraints.NotBlank
 import org.appjam.smashing.domain.game.dto.command.GameResultRejectCommand
 import org.appjam.smashing.domain.game.enums.GameResultRejectReason
 import org.appjam.smashing.global.common.validator.annotation.ValidEnum
-import org.appjam.smashing.global.extensions.ofIgnoreCase
+import org.appjam.smashing.global.extensions.ofIgnoreCaseOrNull
 
 data class GameResultRejectRequest(
-    @field:NotBlank(message = "reason은 필수입니다.")
     @field:ValidEnum(message = "잘못된 reason 값입니다.", enumClass = GameResultRejectReason::class)
-    val reason: String?,
+    val reason: String? = null,
 ) {
     fun toCommand() = GameResultRejectCommand(
-        reason = ofIgnoreCase<GameResultRejectReason>(reason!!),
+        reason = ofIgnoreCaseOrNull<GameResultRejectReason>(reason),
     )
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/game/entity/GameResultSubmission.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/entity/GameResultSubmission.kt
@@ -132,7 +132,7 @@ class GameResultSubmission(
         this.actedAt = actedAt
     }
 
-    fun reject(
+    fun rejectWithReason(
         reason: GameResultRejectReason,
         actedAt: LocalDateTime,
     ) {

--- a/src/main/kotlin/org/appjam/smashing/domain/game/enums/GameResultRejectReason.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/enums/GameResultRejectReason.kt
@@ -1,6 +1,8 @@
 package org.appjam.smashing.domain.game.enums
 
 enum class GameResultRejectReason {
-    SCORE_MISMATCH,      // 점수 불일치
-    WIN_LOSE_REVERSED    // 승패 반전
+    SCORE_MISMATCH,               // 점수 오류
+    WIN_LOSE_REVERSED,            // 승패 반전
+    SCORE_AND_WIN_LOSE_MISMATCH,  // 승패 반전 + 점수 오류
+    GAME_NOT_PLAYED_YET,          // 아직 진행되지 않은 경기
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
@@ -283,7 +283,7 @@ class GameService(
         submissionId: String,
         command: GameResultRejectCommand,
     ) {
-        val now = LocalDateTime.now(DEFAULT_ZONE_ID) // TODO: 인증인가 회복시 변경
+        val now = LocalDateTime.now(DEFAULT_ZONE_ID)// TODO: 인증인가 회복시 변경
 
         // 게임 조회(잠금)
         val game = gameRepository.findByIdForUpdate(gameId)
@@ -303,47 +303,54 @@ class GameService(
             throw CustomException(ErrorCode.GAME_SUBMISSION_NOT_SUBMITTED)
         }
 
-        // 받은 사람만 거절 가능
+        // confirmer 검증
         if (submission.confirmer.id != confirmerUserId) {
             throw CustomException(ErrorCode.GAME_SUBMISSION_CONFIRMER_MISMATCH)
         }
 
-        // 상태 변경
+        // 재제출 가능하도록 게임 상태를 REJECTED로
         game.markRejected()
-        submission.reject(
-            reason = command.reason,
-            actedAt = now,
-        )
 
-        val sportId = game.sport.id!!
-
-        // 게임 상태 변경 SSE 발행
+        // 상태 변경 SSE는 항상 보내도록
         publishGameUpdated(
             receiverUserId = submission.submitter.id!!,
             gameId = game.id!!,
             resultStatus = game.resultStatus,
         )
 
-        val receiverProfile = userSportProfileRepository.findByUserIdAndSportIdFetch(
-            userId = submission.submitter.id!!,
-            sportId = sportId,
-        ) ?: throw CustomException(ErrorCode.USER_SPORT_PROFILE_NOT_FOUND)
+        if (submission.attemptNo == 1) {
+            // 1회차 반려: 사유 필수 + 알림/SSE 발행
+            val reason = command.reason ?: throw CustomException(ErrorCode.GAME_RESULT_REJECT_REASON_REQUIRED_ON_FIRST_REJECT)
 
-        val rejectorProfile = userSportProfileRepository.findByUserIdAndSportIdFetch(
-            userId = submission.confirmer.id!!,
-            sportId = sportId,
-        ) ?: throw CustomException(ErrorCode.USER_SPORT_PROFILE_NOT_FOUND)
+            submission.rejectWithReason(
+                reason = reason,
+                actedAt = now,
+            )
 
-        // 결과 거절 알림 + SSE 발행
-        notifyGameResultRejected(
-            receiver = submission.submitter,
-            receiverProfile = receiverProfile,
-            rejector = submission.confirmer,
-            rejectorTierCode = rejectorProfile.tier.code,
-            gameId = game.id!!,
-            submissionId = submission.id!!,
-            reason = command.reason,
-        )
+            val receiverProfile = userSportProfileRepository.findByUserIdAndSportIdFetch(
+                userId = submission.submitter.id!!,
+                sportId = game.sport.id!!,
+            ) ?: throw CustomException(ErrorCode.USER_SPORT_PROFILE_NOT_FOUND)
+
+            val rejectorProfile = userSportProfileRepository.findByUserIdAndSportIdFetch(
+                userId = submission.confirmer.id!!,
+                sportId = game.sport.id!!,
+            ) ?: throw CustomException(ErrorCode.USER_SPORT_PROFILE_NOT_FOUND)
+
+            notifyGameResultRejected(
+                receiver = submission.submitter,
+                receiverProfile = receiverProfile,
+                rejector = submission.confirmer,
+                rejectorTierCode = rejectorProfile.tier.code,
+                gameId = game.id!!,
+                submissionId = submission.id!!,
+                reason = reason,
+            )
+            return
+        }
+
+        // 2회차 이상 반려: 제출안 삭제 + 알림/SSE 없음
+        submissionRepository.delete(submission)
     }
 
     @Transactional
@@ -785,6 +792,8 @@ class GameService(
         val notificationType = when (reason) {
             GameResultRejectReason.SCORE_MISMATCH -> NotificationType.RESULT_REJECTED_SCORE_MISMATCH
             GameResultRejectReason.WIN_LOSE_REVERSED -> NotificationType.RESULT_REJECTED_WIN_LOSE_REVERSED
+            GameResultRejectReason.SCORE_AND_WIN_LOSE_MISMATCH -> NotificationType.RESULT_REJECTED_SCORE_AND_WIN_LOSE_MISMATCH
+            GameResultRejectReason.GAME_NOT_PLAYED_YET -> NotificationType.RESULT_REJECTED_GAME_NOT_PLAYED_YET
         }
 
         val notification = notificationService.createResultRejected(

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/entity/Notification.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/entity/Notification.kt
@@ -170,6 +170,38 @@ class Notification(
             receiverSportId = receiverProfile.sport.id!!, // TODO: 발신자 프로필 ID 추가
             notificationTemplate = template,
         )
+
+        fun createResultRejectedScoreAndWinLoseMismatch(
+            receiver: User,
+            receiverProfile: UserSportProfile,
+            template: NotificationTemplate,
+            rejectorNickname: String,
+        ) = Notification(
+            params = """{"sportName":"${receiverProfile.sport.name}","rejectorNickname":"$rejectorNickname"}""",
+            isRead = false,
+            linkUrl = "/api/v1/users/me/games/pending-results",
+            user = receiver,
+            senderNickname = rejectorNickname,
+            receiverProfileId = receiverProfile.id!!,
+            receiverSportId = receiverProfile.sport.id!!,
+            notificationTemplate = template,
+        )
+
+        fun createResultRejectedGameNotPlayedYet(
+            receiver: User,
+            receiverProfile: UserSportProfile,
+            template: NotificationTemplate,
+            rejectorNickname: String,
+        ) = Notification(
+            params = """{"sportName":"${receiverProfile.sport.name}","rejectorNickname":"$rejectorNickname"}""",
+            isRead = false,
+            linkUrl = "/api/v1/users/me/games/pending-results",
+            user = receiver,
+            senderNickname = rejectorNickname,
+            receiverProfileId = receiverProfile.id!!,
+            receiverSportId = receiverProfile.sport.id!!,
+            notificationTemplate = template,
+        )
     }
 
     fun markAsRead() {

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/enums/NotificationType.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/enums/NotificationType.kt
@@ -11,6 +11,8 @@ enum class NotificationType {
     // 경기 결과 관련
     RESULT_REJECTED_SCORE_MISMATCH,     // 결과 반려 - 점수 오류
     RESULT_REJECTED_WIN_LOSE_REVERSED,  // 결과 반려 - 승패 오류
+    RESULT_REJECTED_SCORE_AND_WIN_LOSE_MISMATCH,    // 결과 반려 - 점수 및 승패 오류
+    RESULT_REJECTED_GAME_NOT_PLAYED_YET,            // 결과 반려 - 경기 미진행
 
     // 후기 관련
     REVIEW_RECEIVED               // 후기 도착

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/service/NotificationService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/service/NotificationService.kt
@@ -129,6 +129,22 @@ class NotificationService(
                     rejectorNickname = rejectorNickname,
                 )
 
+            NotificationType.RESULT_REJECTED_SCORE_AND_WIN_LOSE_MISMATCH ->
+                Notification.createResultRejectedScoreAndWinLoseMismatch(
+                    receiver = receiver,
+                    receiverProfile = receiverProfile,
+                    template = template,
+                    rejectorNickname = rejectorNickname,
+                )
+
+            NotificationType.RESULT_REJECTED_GAME_NOT_PLAYED_YET ->
+                Notification.createResultRejectedGameNotPlayedYet(
+                    receiver = receiver,
+                    receiverProfile = receiverProfile,
+                    template = template,
+                    rejectorNickname = rejectorNickname,
+                )
+
             else -> throw CustomException(ErrorCode.NOTIFICATION_RESULT_REJECTED_TYPE_MISMATCH)
         }
 

--- a/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
@@ -86,6 +86,7 @@ enum class ErrorCode(
     GAME_SUBMISSION_CONFIRMER_MISMATCH(HttpStatus.FORBIDDEN, "GAME-015", "해당 제출안을 확정할 권한이 없습니다."),
     GAME_RESULT_ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST, "GAME-016", "확정된 경기는 삭제할 수 없습니다."),
     GAME_RESULT_RESUBMIT_ONLY_PREVIOUS_SUBMITTER(HttpStatus.FORBIDDEN, "GAME-017", "재제출은 기존에 결과를 제출했던 사용자만 가능합니다."),
+    GAME_RESULT_REJECT_REASON_REQUIRED_ON_FIRST_REJECT(HttpStatus.BAD_REQUEST, "GAME_018", "첫 번째 반려에는 반려 사유가 필수입니다.",),
 
     // Domain - Game Review
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "GAMEREVIEW-001", "해당 리뷰를 찾을 수 없습니다."),


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #137 

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
-결과 반려 API 수정

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 두번째 반려에는 반려 사유 제출하지 않음 -> nullable하게 변경
- [x] 반려 사유 2개 추가 (승패반전+점수오류, 경기 미진행)

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 
<img width="693" height="493" alt="image" src="https://github.com/user-attachments/assets/1c1a87fe-7b5f-4898-a81b-64d0a23a1a96" />


## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 내용