### PR TITLE
[FIX] 리뷰 목록 조회 API / NULL일 경우 수정

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/domain/review/dto/projection/UserRecentGameProjection.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/review/dto/projection/UserRecentGameProjection.kt
@@ -9,7 +9,7 @@ data class UserRecentGameProjection(
     val gameReviewId: String,
     val opponentNickname: String,
     val createdAt: LocalDateTime,
-    val content: String?,
+    val content: String,
 ) : CursorKey {
     override val cursorId: String
         get() = gameReviewId

--- a/src/main/kotlin/org/appjam/smashing/domain/review/repository/GameReviewRepositoryCustomImpl.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/review/repository/GameReviewRepositoryCustomImpl.kt
@@ -28,6 +28,8 @@ class GameReviewRepositoryCustomImpl(
             .and(gr.reviewee.id.eq(userId))
             .and(gr.game.sport.id.eq(sportId))
             .and(gr.createdAt.loe(snapshotAt.toLocalDateTime()))
+            .and(gr.content.isNotNull)
+            .and(gr.content.isNotEmpty)
 
         if (cursor != null) {
             where.and(gr.id.lt(cursor.id))


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #153

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 리뷰 NULL일 경우 목록에서 제외하도록 수정

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 나의 최근 리뷰 목록 조회 API
- [x] 유저의 최근 리뷰 목록 조회 API

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 리뷰는 한 건 있지만
<img width="380" height="343" alt="image" src="https://github.com/user-attachments/assets/ae592ca2-e464-4f69-932d-bf8caf289ff2" />

- content가 Null일시 리뷰 목록에 뜨지 않음
<img width="494" height="233" alt="image" src="https://github.com/user-attachments/assets/89b0a416-6f00-4fff-b0f3-e3d64138f1ef" />


## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 내용