### PR TITLE
[FIX] 큐에이 오류 해결 / 커서 

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/projection/OtherUserRegionCursor.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/projection/OtherUserRegionCursor.kt
@@ -1,0 +1,7 @@
+package org.appjam.smashing.domain.user.dto.projection
+
+data class OtherUserRegionCursor(
+    val reviewCount: Long,
+    val totalGames: Long,
+    val nickname: String,
+)

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/projection/OtherUserRegionCursor.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/projection/OtherUserRegionCursor.kt
@@ -1,7 +1,9 @@
 package org.appjam.smashing.domain.user.dto.projection
 
+import org.appjam.smashing.global.common.dto.CursorPayload
+
 data class OtherUserRegionCursor(
     val reviewCount: Long,
     val totalGames: Long,
     val nickname: String,
-)
+) : CursorPayload

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/projection/OtherUserRegionProjection.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/projection/OtherUserRegionProjection.kt
@@ -2,7 +2,7 @@ package org.appjam.smashing.domain.user.dto.projection
 
 import com.querydsl.core.annotations.QueryProjection
 import org.appjam.smashing.domain.tier.enums.TierCode
-import org.appjam.smashing.global.common.dto.CursorKey
+import org.appjam.smashing.global.common.dto.CompositeCursorKey
 
 @QueryProjection
 data class OtherUserRegionProjection(
@@ -13,7 +13,14 @@ data class OtherUserRegionProjection(
     val wins: Int,
     val losses: Int,
     val reviews: Long,
-) : CursorKey {
+) : CompositeCursorKey {
     override val cursorId: String
         get() = userId
+
+    override fun toCursorPayload() =
+        OtherUserRegionCursor(
+            reviewCount = reviews,
+            totalGames = (wins + losses).toLong(),
+            nickname = nickname,
+        )
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/projection/OtherUserRegionProjection.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/projection/OtherUserRegionProjection.kt
@@ -2,7 +2,8 @@ package org.appjam.smashing.domain.user.dto.projection
 
 import com.querydsl.core.annotations.QueryProjection
 import org.appjam.smashing.domain.tier.enums.TierCode
-import org.appjam.smashing.global.common.dto.CompositeCursorKey
+import org.appjam.smashing.global.common.dto.CursorKey
+import org.appjam.smashing.global.common.dto.CursorPayload
 
 @QueryProjection
 data class OtherUserRegionProjection(
@@ -13,11 +14,11 @@ data class OtherUserRegionProjection(
     val wins: Int,
     val losses: Int,
     val reviews: Long,
-) : CompositeCursorKey {
+) : CursorKey {
     override val cursorId: String
         get() = userId
 
-    override fun toCursorPayload() =
+    override fun toCursorPayload(): CursorPayload =
         OtherUserRegionCursor(
             reviewCount = reviews,
             totalGames = (wins + losses).toLong(),

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepositoryCustomImpl.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepositoryCustomImpl.kt
@@ -94,13 +94,27 @@ class UserSportProfileRepositoryCustomImpl(
         snapshotAt: OffsetDateTime,
     ): CursorPageResponse<OtherUserRegionProjection> {
         val size = request.size.coerceIn(1, 50).toInt()
-        val cursor = cursorCodec.decode(request.cursor)
+        val cursor = cursorCodec.decode(request.cursor, OtherUserRegionCursor::class.java)
 
         val snapshotLocal = snapshotAt
             .atZoneSameInstant(TimeUtils.DEFAULT_ZONE_ID)
             .toLocalDateTime()
 
         val totalGamesExpression = userSportProfile.wins.add(userSportProfile.losses)
+            .castToNum(Long::class.javaObjectType)
+
+        val reviewCountExpression = JPAExpressions
+            .select(gameReview.count())
+            .from(gameReview)
+            .where(
+                gameReview.reviewee.id.eq(user.id),
+                gameReview.game.sport.id.eq(sportId),
+            )
+        val reviewCountOrderExpression = Expressions.numberTemplate(
+            Long::class.javaObjectType,
+            "({0})",
+            reviewCountExpression
+        )
 
         val where = BooleanBuilder()
             .and(user.region.eq(region))
@@ -111,23 +125,20 @@ class UserSportProfileRepositoryCustomImpl(
         gender?.let { where.and(user.gender.eq(gender)) }
         tier?.let { where.and(userSportProfile.tier.name.startsWithIgnoreCase(tier)) }
 
-        if (cursor != null) {
-            where.and(user.id.lt(cursor.id))
+        cursor?.let { lastCursor ->
+            val cursorWhere =
+                reviewCountOrderExpression.lt(lastCursor.reviewCount)
+                    .or(
+                        reviewCountOrderExpression.eq(lastCursor.reviewCount)
+                            .and(totalGamesExpression.lt(lastCursor.totalGames))
+                    )
+                    .or(
+                        reviewCountOrderExpression.eq(lastCursor.reviewCount)
+                            .and(totalGamesExpression.eq(lastCursor.totalGames))
+                            .and(user.nickname.gt(lastCursor.nickname))
+                    )
+            where.and(cursorWhere)
         }
-
-        val reviewCountExpression = JPAExpressions
-            .select(gameReview.count())
-            .from(gameReview)
-            .where(
-                gameReview.reviewee.id.eq(user.id),
-                gameReview.game.sport.id.eq(sportId)
-            )
-
-        val reviewCountOrderExpression = Expressions.numberTemplate(
-            Long::class.java,
-            "({0})",
-            reviewCountExpression
-        )
 
         val projections = queryFactory
             .select(

--- a/src/main/kotlin/org/appjam/smashing/global/common/dto/CursorResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/common/dto/CursorResponse.kt
@@ -3,10 +3,6 @@ package org.appjam.smashing.global.common.dto
 import org.appjam.smashing.global.util.CursorCodec
 import java.time.OffsetDateTime
 
-interface CompositeCursorKey : CursorKey {
-    fun toCursorPayload(): Any
-}
-
 data class CursorResponse<T>(
     val snapshotAt: OffsetDateTime,
     val results: List<T>,

--- a/src/main/kotlin/org/appjam/smashing/global/common/dto/CursorResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/common/dto/CursorResponse.kt
@@ -27,10 +27,7 @@ data class CursorPageResponse<T : CursorKey>(
             val results = if (hasNext) fetched.take(pageSize) else fetched
 
             val nextCursor = if (hasNext && results.isNotEmpty()) {
-                when (val last = results.last()) {
-                    is CompositeCursorKey -> cursorCodec.encode(last.toCursorPayload())
-                    else -> cursorCodec.encode(IdCursor(id = last.cursorId))
-                }
+                cursorCodec.encode(results.last().toCursorPayload())
             } else null
 
             return CursorPageResponse(

--- a/src/main/kotlin/org/appjam/smashing/global/common/dto/CursorResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/common/dto/CursorResponse.kt
@@ -3,6 +3,10 @@ package org.appjam.smashing.global.common.dto
 import org.appjam.smashing.global.util.CursorCodec
 import java.time.OffsetDateTime
 
+interface CompositeCursorKey : CursorKey {
+    fun toCursorPayload(): Any
+}
+
 data class CursorResponse<T>(
     val snapshotAt: OffsetDateTime,
     val results: List<T>,
@@ -27,7 +31,10 @@ data class CursorPageResponse<T : CursorKey>(
             val results = if (hasNext) fetched.take(pageSize) else fetched
 
             val nextCursor = if (hasNext && results.isNotEmpty()) {
-                cursorCodec.encode(IdCursor(id = results.last().cursorId))
+                when (val last = results.last()) {
+                    is CompositeCursorKey -> cursorCodec.encode(last.toCursorPayload())
+                    else -> cursorCodec.encode(IdCursor(id = last.cursorId))
+                }
             } else null
 
             return CursorPageResponse(

--- a/src/main/kotlin/org/appjam/smashing/global/common/dto/IdCursor.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/common/dto/IdCursor.kt
@@ -7,3 +7,7 @@ data class IdCursor(
 interface CursorKey {
     val cursorId: String
 }
+
+interface CompositeCursorKey : CursorKey {
+    fun toCursorPayload(): Any
+}

--- a/src/main/kotlin/org/appjam/smashing/global/common/dto/IdCursor.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/common/dto/IdCursor.kt
@@ -1,13 +1,13 @@
 package org.appjam.smashing.global.common.dto
 
-data class IdCursor(
-    val id: String,
-)
+interface CursorPayload
 
 interface CursorKey {
     val cursorId: String
+
+    fun toCursorPayload(): CursorPayload = IdCursor(cursorId)
 }
 
-interface CompositeCursorKey : CursorKey {
-    fun toCursorPayload(): Any
-}
+data class IdCursor(
+    val id: String,
+) : CursorPayload

--- a/src/main/kotlin/org/appjam/smashing/global/util/CursorCodec.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/util/CursorCodec.kt
@@ -3,6 +3,8 @@ package org.appjam.smashing.global.util
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.appjam.smashing.global.common.dto.CursorPayload
 import org.appjam.smashing.global.common.dto.IdCursor
+import org.appjam.smashing.global.exception.CustomException
+import org.appjam.smashing.global.exception.ErrorCode
 import org.springframework.stereotype.Component
 import java.nio.charset.StandardCharsets
 import java.util.*
@@ -39,11 +41,15 @@ class CursorCodec(
     ): T? {
         if (cursor.isNullOrBlank()) return null
 
-        val json = String(
-            Base64.getUrlDecoder().decode(cursor),
-            StandardCharsets.UTF_8,
-        )
+        return runCatching {
+            val json = String(
+                Base64.getUrlDecoder().decode(cursor),
+                StandardCharsets.UTF_8,
+            )
 
-        return objectMapper.readValue(json, clazz)
+            objectMapper.readValue(json, clazz)
+        }.getOrElse {
+            throw CustomException(ErrorCode.BAD_REQUEST)
+        }
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/global/util/CursorCodec.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/util/CursorCodec.kt
@@ -32,17 +32,17 @@ class CursorCodec(
         return objectMapper.readValue(json, IdCursor::class.java)
     }
 
-    fun <T> decode(cursor: String?, clazz: Class<T>): T? {
+    fun <T> decode(
+        cursor: String?,
+        clazz: Class<T>,
+    ): T? {
         if (cursor.isNullOrBlank()) return null
 
-        return try {
-            val json = String(
-                Base64.getUrlDecoder().decode(cursor),
-                StandardCharsets.UTF_8,
-            )
-            objectMapper.readValue(json, clazz)
-        } catch (e: Exception) {
-            null
-        }
+        val json = String(
+            Base64.getUrlDecoder().decode(cursor),
+            StandardCharsets.UTF_8,
+        )
+
+        return objectMapper.readValue(json, clazz)
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/global/util/CursorCodec.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/util/CursorCodec.kt
@@ -1,6 +1,7 @@
 package org.appjam.smashing.global.util
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.appjam.smashing.global.common.dto.CursorPayload
 import org.appjam.smashing.global.common.dto.IdCursor
 import org.springframework.stereotype.Component
 import java.nio.charset.StandardCharsets
@@ -11,7 +12,7 @@ class CursorCodec(
     private val objectMapper: ObjectMapper,
 ) {
     fun encode(
-        cursor: Any
+        cursor: CursorPayload
     ): String {
         val json = objectMapper.writeValueAsString(cursor)
         return Base64.getUrlEncoder()

--- a/src/main/kotlin/org/appjam/smashing/global/util/CursorCodec.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/util/CursorCodec.kt
@@ -4,15 +4,14 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.appjam.smashing.global.common.dto.IdCursor
 import org.springframework.stereotype.Component
 import java.nio.charset.StandardCharsets
-import java.util.Base64
+import java.util.*
 
 @Component
 class CursorCodec(
     private val objectMapper: ObjectMapper,
 ) {
-
     fun encode(
-        cursor: IdCursor
+        cursor: Any
     ): String {
         val json = objectMapper.writeValueAsString(cursor)
         return Base64.getUrlEncoder()
@@ -31,5 +30,19 @@ class CursorCodec(
         )
 
         return objectMapper.readValue(json, IdCursor::class.java)
+    }
+
+    fun <T> decode(cursor: String?, clazz: Class<T>): T? {
+        if (cursor.isNullOrBlank()) return null
+
+        return try {
+            val json = String(
+                Base64.getUrlDecoder().decode(cursor),
+                StandardCharsets.UTF_8,
+            )
+            objectMapper.readValue(json, clazz)
+        } catch (e: Exception) {
+            null
+        }
     }
 }


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #155

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 커서 관련된 이슈를 해결했습니다.
  - `문제 상황`:  다음 커서가 있을 때 아이디 값을 cursor 안에 넣어 요청하면 그 다음 데이터 값이 꼬여서 나왔습니다. (결국, 중복되는 데이터 노출 문제도 발생)
  - `원인` : 정렬 기준과 커서 기준이 맞지 않았습니다.  정렬 기준이 복합이기 때문에(후기순 → 경기순 → 닉네임순) 커서도 복합 커서로 구현을 해줘야 했습니다.
  - `해결 방법` : 
       - OtherUserRegionCursor 커서 dto를 만들어 정렬기준과 동일한 커서를 만들어 줬습니다.
       - 기존 encode 함수의 매개변수 타입을 IdCursor에서 Any로 바꾸어 어떤 커서든 encode 가능하게 수정했습니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 복합 커서 구현

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 내용

## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 내용