### PR TITLE
refac: #169 #184 #176 매칭 신청 API, 보낸 매칭 요청 취소 API, 매칭 요청 거절 API 리팩토링

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepository.kt
@@ -9,6 +9,35 @@ import org.springframework.data.repository.query.Param
 import java.time.LocalDateTime
 
 interface GameRepository : JpaRepository<Game, String>, GameRepositoryCustom {
+
+    /**
+     * 하루 3판 제한(종목별 동일 상대) 판단용
+     * - 오늘 RESULT_CONFIRMED 된 게임 수 카운트 (양방향 합산)
+     */
+    @Query(
+        value = """
+        select count(*)
+        from game g
+        join matching m on m.id = g.matching_id
+        where g.sport_id = :sportId
+          and g.result_status = 'RESULT_CONFIRMED'
+          and g.confirmed_at >= :startOfDay
+          and g.confirmed_at < :endOfDay
+          and (
+                (m.requester_profile_id = :profileA and m.receiver_profile_id = :profileB)
+             or (m.requester_profile_id = :profileB and m.receiver_profile_id = :profileA)
+          )
+        """,
+        nativeQuery = true
+    )
+    fun countConfirmedGamesTodayBetweenProfiles(
+        @Param("profileA") profileA: String,
+        @Param("profileB") profileB: String,
+        @Param("sportId") sportId: Long,
+        @Param("startOfDay") startOfDay: LocalDateTime,
+        @Param("endOfDay") endOfDay: LocalDateTime,
+    ): Long
+
     fun existsByMatchingId(
         matchingId: String
     ): Boolean

--- a/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
@@ -76,8 +76,8 @@ class GameService(
         }
 
         // 제출자/상대 결정
-        val requester = game.matching.requester
-        val receiver = game.matching.receiver
+        val requester = game.matching.requesterProfile.user
+        val receiver = game.matching.receiverProfile.user
         val (submitter, confirmer) = determineSubmitterAndConfirmer(submitterUserId, requester, receiver)
 
         val submitterProfile = userSportProfileRepository.findByUserIdAndSportIdFetch(
@@ -393,8 +393,8 @@ class GameService(
 
         // 상대방 userId 조회
         val opponentUserId = resolveOpponentUserId(
-            requesterId = game.matching.requester.id!!,
-            receiverId = game.matching.receiver.id!!,
+            requesterId = game.matching.requesterProfile.user.id!!,
+            receiverId = game.matching.receiverProfile.user.id!!,
             userId = userId,
         )
 
@@ -574,8 +574,8 @@ class GameService(
         winnerUserId: String,
         loserUserId: String,
     ): Pair<User, User> {
-        val requester = game.matching.requester
-        val receiver = game.matching.receiver
+        val requester = game.matching.requesterProfile.user
+        val receiver = game.matching.receiverProfile.user
 
         val winner = if (winnerUserId == requester.id!!) requester else receiver
         val loser = if (loserUserId == requester.id!!) requester else receiver
@@ -622,8 +622,8 @@ class GameService(
         val now = LocalDateTime.now(DEFAULT_ZONE_ID)
         val startOfDay = now.toLocalDate().atStartOfDay()
 
-        val requesterId = game.matching.requester.id!!
-        val receiverId = game.matching.receiver.id!!
+        val requesterId = game.matching.requesterProfile.user.id!!
+        val receiverId = game.matching.receiverProfile.user.id!!
 
         val todayConfirmedCount = gameRepository.countTodayConfirmedGamesBetweenUsers(
             startAt = startOfDay,

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/controller/MatchingController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/controller/MatchingController.kt
@@ -69,6 +69,30 @@ class MatchingController(
     }
 
     @Operation(
+        summary = "매칭 요청 거절 API",
+        description = """
+        수신자가 받은 매칭 요청을 거절합니다.
+        - REQUESTED 상태에서만 거절 가능
+        - 거절 시 soft delete 처리
+        - SSE(matching.updated: REJECTED) 를
+          1) receiver(거절한 사람)에게 전송 → 받은 매칭 탭 카드 제거
+          2) requester(요청 보낸 사람)에게 전송 → 보낸 매칭 탭 카드 제거
+    """
+    )
+    @PostMapping("/{matchingId}/reject")
+    fun rejectMatching(
+        @AuthenticationPrincipal principal: CustomUserDetails,
+        @PathVariable matchingId: String,
+    ): ResponseEntity<ApiResponse<Unit>> {
+        matchingService.rejectMatching(
+            receiverUserId = principal.username,
+            matchingId = matchingId,
+        )
+
+        return ApiResponse.success()
+    }
+
+    @Operation(
         summary = "매칭 요청 수락 API",
         description = """
             매칭 요청(matchingId)을 수락합니다.
@@ -81,29 +105,6 @@ class MatchingController(
         @PathVariable matchingId: String,
     ): ResponseEntity<ApiResponse<Unit>> {
         matchingService.acceptMatching(
-            receiverUserId = principal.username,
-            matchingId = matchingId,
-        )
-
-        return ApiResponse.success()
-    }
-
-    @Operation(
-        summary = "매칭 요청 거절 API",
-        description = """
-            수신자가 받은 매칭 요청을 거절합니다.
-            - REQUESTED 상태에서만 거절 가능
-            - 거절 시 soft delete 처리
-            - Notification 생성 없음
-            - requester에게 SSE(matching.updated: REJECTED) 전송
-        """
-    )
-    @PostMapping("/{matchingId}/reject")
-    fun rejectMatching(
-        @AuthenticationPrincipal principal: CustomUserDetails,
-        @PathVariable matchingId: String,
-    ): ResponseEntity<ApiResponse<Unit>> {
-        matchingService.rejectMatching(
             receiverUserId = principal.username,
             matchingId = matchingId,
         )

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/controller/MatchingController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/controller/MatchingController.kt
@@ -46,6 +46,29 @@ class MatchingController(
     }
 
     @Operation(
+        summary = "보낸 매칭 요청 취소 API",
+        description = """
+            보낸 매칭 요청을 취소합니다.
+            - REQUESTED 상태에서만 취소 가능
+            - 취소 시 status=CANCELLED + respondedAt 기록
+            - soft delete 처리
+            - receiver에게 SSE(matching.updated: CANCELLED) 전송
+        """
+    )
+    @DeleteMapping("/{matchingId}")
+    fun cancelMyMatchingRequest(
+        @AuthenticationPrincipal principal: CustomUserDetails,
+        @PathVariable matchingId: String,
+    ): ResponseEntity<ApiResponse<Unit>> {
+        matchingService.cancelMyMatchingRequest(
+            requesterUserId = principal.username,
+            matchingId = matchingId,
+        )
+
+        return ApiResponse.success()
+    }
+
+    @Operation(
         summary = "매칭 요청 수락 API",
         description = """
             매칭 요청(matchingId)을 수락합니다.
@@ -82,29 +105,6 @@ class MatchingController(
     ): ResponseEntity<ApiResponse<Unit>> {
         matchingService.rejectMatching(
             receiverUserId = principal.username,
-            matchingId = matchingId,
-        )
-
-        return ApiResponse.success()
-    }
-
-    @Operation(
-        summary = "내가 보낸 매칭 요청 삭제 API",
-        description = """
-            내가 보낸 매칭 요청을 삭제합니다.
-            - REQUESTED 상태에서만 삭제 가능
-            - 삭제 시 soft delete 처리
-            - Notification 생성 없음
-            - receiver에게 SSE(matching.updated: CANCELLED) 전송
-        """
-    )
-    @DeleteMapping("/{matchingId}")
-    fun cancelMyMatchingRequest(
-        @AuthenticationPrincipal principal: CustomUserDetails,
-        @PathVariable matchingId: String,
-    ): ResponseEntity<ApiResponse<Unit>> {
-        matchingService.cancelMyMatchingRequest(
-            requesterUserId = principal.username,
             matchingId = matchingId,
         )
 

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/controller/MatchingController.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/controller/MatchingController.kt
@@ -24,10 +24,12 @@ class MatchingController(
         summary = "매칭 신청 API",
         description = """
             상대 스포츠 프로필(receiverProfileId)에 대해 매칭을 신청합니다.
-            - 인증된 사용자 기준으로 매칭 요청을 생성합니다.
-            - 동일 유저 간 하루 최대 3회 신청 가능합니다. (앱잼 제외)
-            - 상대방에게 24시간 이내 결과까지 모두 확정되지 않은 이력이 존재할 경우 신청 불가합니다.
-            - 성공 시 상대 유저에게 알림 및 SSE 이벤트가 전송됩니다.
+            - 종목은 receiverProfile의 sport로 결정됩니다.
+            - 동일 종목/동일 상대 하루 3판 제한: "오늘 RESULT_CONFIRMED 게임 수" 기준
+            - 24시간 쿨다운: REQUESTED(createdAt), CANCELLED/REJECTED(respondedAt) 기준
+            - 성공 시:
+              1) 상대 유저에게 Notification 저장(실시간 반영 X)
+              2) SSE: receiver에게 matching.received, requester에게 matching.sent
         """
     )
     @PostMapping("/profiles/{receiverProfileId}")

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/dto/projection/LatestMatchingCooldownProjection.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/dto/projection/LatestMatchingCooldownProjection.kt
@@ -1,0 +1,9 @@
+package org.appjam.smashing.domain.matching.dto.projection
+
+import java.time.LocalDateTime
+
+interface LatestMatchingCooldownProjection {
+    val status: String
+    val createdAt: LocalDateTime
+    val respondedAt: LocalDateTime?
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/entity/Matching.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/entity/Matching.kt
@@ -6,6 +6,7 @@ import org.appjam.smashing.domain.common.entity.BaseEntity
 import org.appjam.smashing.domain.matching.enums.MatchingStatus
 import org.appjam.smashing.domain.sport.entity.Sport
 import org.appjam.smashing.domain.user.entity.User
+import org.appjam.smashing.domain.user.entity.UserSportProfile
 import org.hibernate.annotations.Comment
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
@@ -14,9 +15,10 @@ import java.time.LocalDateTime
 @Entity
 @Table(
     indexes = [
-        Index(name = "idx_matching_requester_user_id", columnList = "requester_user_id"),
-        Index(name = "idx_matching_receiver_user_id", columnList = "receiver_user_id"),
+        Index(name = "idx_matching_requester_profile_id", columnList = "requester_profile_id"),
+        Index(name = "idx_matching_receiver_profile_id", columnList = "receiver_profile_id"),
         Index(name = "idx_matching_sport_id", columnList = "sport_id"),
+        Index(name = "idx_matching_sport_req_recv", columnList = "sport_id, requester_profile_id, receiver_profile_id"),
     ]
 )
 @Comment("매칭 정보")
@@ -44,21 +46,37 @@ class Matching(
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(
-        name = "requester_user_id",
+        name = "requester_profile_id",
         nullable = false,
         foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT)
     )
-    @Comment("발신자 유저 IDX")
-    val requester: User,
+    @Comment("발신자 유저-스포츠 프로필 IDX")
+    val requesterProfile: UserSportProfile,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(
-        name = "receiver_user_id",
+        name = "requester_id",
+        foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT)
+    )
+    @Comment("발신자 유저 IDX")
+    val requester: User ?=null,// TODO: 매칭 관련 리팩토링 완료 후 삭제 예정
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(
+        name = "receiver_profile_id",
         nullable = false,
         foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT)
     )
+    @Comment("수신자 유저-스포츠 프로필 IDX")
+    val receiverProfile: UserSportProfile,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(
+        name = "receiver_id",
+        foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT)
+    )
     @Comment("수신자 유저 IDX")
-    val receiver: User,
+    val receiver: User ?=null,// TODO: 매칭 관련 리팩토링 완료 후 삭제 예정
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(
@@ -72,12 +90,12 @@ class Matching(
 
     companion object {
         fun createRequested(
-            requester: User,
-            receiver: User,
+            requesterProfile: UserSportProfile,
+            receiverProfile: UserSportProfile,
             sport: Sport,
         ): Matching = Matching(
-            requester = requester,
-            receiver = receiver,
+            requesterProfile = requesterProfile,
+            receiverProfile = receiverProfile,
             sport = sport,
         )
     }

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/enums/MatchingStatus.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/enums/MatchingStatus.kt
@@ -4,6 +4,6 @@ enum class MatchingStatus {
     REQUESTED,       // 매칭 요청
     ACCEPTED,        // 매칭 수락
     REJECTED,        // 매칭 거절
-    CANCELLED,       // 매칭 요청 삭제
+    CANCELLED,       // 보낸 매칭 요청 취소
     COMPLETED        // 매칭 확정
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepository.kt
@@ -41,20 +41,24 @@ interface MatchingRepository : JpaRepository<Matching, String>, MatchingReposito
         @Param("sportId") sportId: Long,
     ): LatestMatchingCooldownProjection?
 
+    /**
+     * 매칭 row에 대해 락을 걸고 조회 (상태 전환이 한번만 일어나도록)
+     */
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query(
         """
         select m
-        from Matching m
-        join fetch m.requester
-        join fetch m.receiver
-        join fetch m.sport
-        where m.id = :matchingId
-          and m.deletedAt is null
+          from Matching m
+          join fetch m.requesterProfile rp
+          join fetch rp.user rpu
+          join fetch m.receiverProfile rcp
+          join fetch rcp.user rcu
+          join fetch m.sport s
+         where m.id = :matchingId
         """
     )
     fun findByIdFetchAllForUpdate(
-        matchingId: String
+        matchingId: String,
     ): Matching?
 
     @Modifying

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/repository/MatchingRepository.kt
@@ -1,15 +1,45 @@
 package org.appjam.smashing.domain.matching.repository
 
 import jakarta.persistence.LockModeType
+import org.appjam.smashing.domain.matching.dto.projection.LatestMatchingCooldownProjection
 import org.appjam.smashing.domain.matching.entity.Matching
 import org.appjam.smashing.domain.matching.enums.MatchingStatus
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.time.LocalDateTime
 
 interface MatchingRepository : JpaRepository<Matching, String>, MatchingRepositoryCustom {
+
+    /**
+     * 마지막 매칭(soft delete 포함) 1건 조회 (쿨다운 판단용)
+     * - cancelled/rejected는 responded_at 기준으로 24h
+     * - requested 상태는 created_at 기준으로 24h
+     */
+    @Query(
+        value = """
+        select 
+            m.status as status,
+            m.created_at as createdAt,
+            m.responded_at as respondedAt
+        from matching m
+        where m.sport_id = :sportId
+          and (
+                (m.requester_profile_id = :profileA and m.receiver_profile_id = :profileB)
+             or (m.requester_profile_id = :profileB and m.receiver_profile_id = :profileA)
+          )
+        order by m.created_at desc
+        limit 1
+        """,
+        nativeQuery = true
+    )
+    fun findLatestForCooldown(
+        @Param("profileA") profileA: String,
+        @Param("profileB") profileB: String,
+        @Param("sportId") sportId: Long,
+    ): LatestMatchingCooldownProjection?
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query(
@@ -57,46 +87,6 @@ interface MatchingRepository : JpaRepository<Matching, String>, MatchingReposito
         sportId: Long,
         status: MatchingStatus
     ): Matching?
-
-    @Query(
-        value = """
-     select exists(
-        select 1
-        from matching m
-        where m.created_at >= :startAt
-          and m.status not in ('ACCEPTED', 'COMPLETED')
-          and m.requester_user_id = :requesterUserId
-          and m.receiver_user_id = :receiverUserId
-    )
-    """,
-        nativeQuery = true
-    )
-    fun existsPendingRequestFromRequesterToReceiverSinceRaw(
-        startAt: LocalDateTime,
-        requesterUserId: String,
-        receiverUserId: String,
-    ): Long
-
-    @Query(
-        value = """
-        select exists(
-            select 1
-              from matching m
-              left join game g
-                     on g.matching_id = m.id
-             where m.created_at >= :startAt
-               and m.requester_user_id = :requesterUserId
-               and m.receiver_user_id = :receiverUserId
-               and (g.id is null or g.result_status <> 'RESULT_CONFIRMED')
-        )
-    """,
-        nativeQuery = true
-    )
-    fun existsUnconfirmedOutgoingMatchingSinceRaw(
-        startAt: LocalDateTime,
-        requesterUserId: String,
-        receiverUserId: String,
-    ): Long
 
     @Query(
         value = """

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
@@ -59,12 +59,10 @@ class MatchingService(
         val requesterProfile = findRequesterProfileBySport(requesterUserId, sportId)
 
         // 하루 (00:00 ~) 최대 3회 게임 가능
-        /* TODO: 앱잼 기간내 하루 3회 제한 해제
         validateDailyLimit(
             requesterUserId = requesterUserId,
             receiverUserId = receiverProfile.user.id!!,
         )
-        */
 
         // 24시간 내 진행되지 않은 매칭 요청 이력이 남아있는 경우, 동일 상대방에 대해 중복 매칭 요청 불가
         validateNoMatchingWithin24h(
@@ -570,6 +568,7 @@ class MatchingService(
         )
     }
 
+    // 삭제 예정
     companion object {
         val DEFAULT_ZONE_ID = ZoneId.of("Asia/Seoul")
     }

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
@@ -171,7 +171,7 @@ class MatchingService(
         validateCancellableByRequester(matching, requesterUserId)
 
         // 취소 처리
-        matching.cancel(LocalDateTime.now(DEFAULT_ZONE_ID))
+        matching.cancel(LocalDateTime.now(TimeUtils.DEFAULT_ZONE_ID))
         matchingRepository.flush()
 
         // soft delete
@@ -184,6 +184,44 @@ class MatchingService(
             payload = MatchingUpdatedPayload(
                 matchingId = matchingId,
                 status = MatchingUpdateStatus.CANCELLED,
+            )
+        )
+    }
+
+    @Transactional
+    fun rejectMatching(
+        receiverUserId: String,
+        matchingId: String,
+    ) {
+        val matching = matchingRepository.findByIdFetchAllForUpdate(matchingId)
+            ?: throw CustomException(ErrorCode.MATCHING_NOT_FOUND)
+
+        validateRejectable(matching, receiverUserId)
+
+        // 거절 처리
+        matching.reject(LocalDateTime.now(TimeUtils.DEFAULT_ZONE_ID))
+        matchingRepository.flush()
+
+        // soft delete
+        matchingRepository.delete(matching)
+
+        // SSE - receiver 받은 매칭 탭에서 카드 제거
+        outboxEventPublisher.publish(
+            userId = receiverUserId,
+            eventType = SseEventType.MATCHING_UPDATED,
+            payload = MatchingUpdatedPayload(
+                matchingId = matchingId,
+                status = MatchingUpdateStatus.REJECTED,
+            )
+        )
+
+        // SSE - requester 보낸 매칭 탭에서 카드 제거
+        outboxEventPublisher.publish(
+            userId = matching.requesterProfile.user.id!!,
+            eventType = SseEventType.MATCHING_UPDATED,
+            payload = MatchingUpdatedPayload(
+                matchingId = matchingId,
+                status = MatchingUpdateStatus.REJECTED,
             )
         )
     }
@@ -253,30 +291,6 @@ class MatchingService(
             receiverProfileId = receiverProfile.id!!,
             receiverUserId = receiverUserId,
             receiverProfile = receiverProfile,
-        )
-    }
-
-    @Transactional
-    fun rejectMatching(
-        receiverUserId: String,
-        matchingId: String,
-    ) {
-        val matching = matchingRepository.findByIdFetchAllForUpdate(matchingId)
-            ?: throw CustomException(ErrorCode.MATCHING_NOT_FOUND)
-
-        validateRejectable(matching, receiverUserId)
-
-        // 상태 변경
-        matching.reject(LocalDateTime.now(DEFAULT_ZONE_ID))
-        matchingRepository.flush()
-
-        // soft delete
-        matchingRepository.delete(matching)
-
-        // SSE 이벤트 발행
-        publishMatchingUpdatedRejected(
-            requesterUserId = matching.requesterProfile.user.id!!,
-            matchingId = matchingId,
         )
     }
 
@@ -355,8 +369,7 @@ class MatchingService(
         profileB: String,
         sportId: Long,
     ) {
-        val zone = TimeUtils.DEFAULT_ZONE_ID
-        val today = LocalDate.now(zone)
+        val today = LocalDate.now(TimeUtils.DEFAULT_ZONE_ID)
         val startOfDay = today.atStartOfDay()
         val endOfDay = today.plusDays(1).atStartOfDay()
 
@@ -445,20 +458,6 @@ class MatchingService(
             payload = MatchingUpdatedPayload(
                 matchingId = matchingId,
                 status = MatchingUpdateStatus.ACCEPTED,
-            )
-        )
-    }
-
-    private fun publishMatchingUpdatedRejected(
-        requesterUserId: String,
-        matchingId: String,
-    ) {
-        outboxEventPublisher.publish(
-            userId = requesterUserId,
-            eventType = SseEventType.MATCHING_UPDATED,
-            payload = MatchingUpdatedPayload(
-                matchingId = matchingId,
-                status = MatchingUpdateStatus.REJECTED,
             )
         )
     }

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
@@ -160,6 +160,33 @@ class MatchingService(
         )
     }
 
+    @Transactional
+    fun cancelMyMatchingRequest(
+        requesterUserId: String,
+        matchingId: String,
+    ) {
+        val matching = matchingRepository.findByIdFetchAllForUpdate(matchingId)
+            ?: throw CustomException(ErrorCode.MATCHING_NOT_FOUND)
+
+        validateCancellableByRequester(matching, requesterUserId)
+
+        // 취소 처리
+        matching.cancel(LocalDateTime.now(DEFAULT_ZONE_ID))
+        matchingRepository.flush()
+
+        // soft delete
+        matchingRepository.delete(matching)
+
+        // SSE - receiver 받은 매칭 탭에서 카드 제거
+        outboxEventPublisher.publish(
+            userId = matching.receiverProfile.user.id!!,
+            eventType = SseEventType.MATCHING_UPDATED,
+            payload = MatchingUpdatedPayload(
+                matchingId = matchingId,
+                status = MatchingUpdateStatus.CANCELLED,
+            )
+        )
+    }
 
     @Transactional
     fun acceptMatching(
@@ -249,30 +276,6 @@ class MatchingService(
         // SSE 이벤트 발행
         publishMatchingUpdatedRejected(
             requesterUserId = matching.requesterProfile.user.id!!,
-            matchingId = matchingId,
-        )
-    }
-
-    @Transactional
-    fun cancelMyMatchingRequest(
-        requesterUserId: String,
-        matchingId: String,
-    ) {
-        val matching = matchingRepository.findByIdFetchAllForUpdate(matchingId)
-            ?: throw CustomException(ErrorCode.MATCHING_NOT_FOUND)
-
-        validateCancellableByRequester(matching, requesterUserId)
-
-        // 상태 변경
-        matching.cancel(LocalDateTime.now(DEFAULT_ZONE_ID))
-        matchingRepository.flush()
-
-        // soft delete
-        matchingRepository.delete(matching)
-
-        // SSE 이벤트 발행
-        publishMatchingUpdatedCancelled(
-            receiverUserId = matching.receiverProfile.user.id!!,
             matchingId = matchingId,
         )
     }
@@ -402,6 +405,21 @@ class MatchingService(
         }
     }
 
+    private fun validateCancellableByRequester(
+        matching: Matching,
+        requesterUserId: String,
+    ) {
+        // requester만 취소 가능
+        if (matching.requesterProfile.user.id!! != requesterUserId) {
+            throw CustomException(ErrorCode.MATCHING_FORBIDDEN)
+        }
+
+        // REQUESTED 상태만 취소 가능
+        if (matching.status != MatchingStatus.REQUESTED) {
+            throw CustomException(ErrorCode.MATCHING_ALREADY_RESPONDED)
+        }
+    }
+
     private fun validateRejectable(
         matching: Matching,
         receiverUserId: String,
@@ -417,22 +435,6 @@ class MatchingService(
         }
     }
 
-    private fun validateCancellableByRequester(
-        matching: Matching,
-        requesterUserId: String,
-    ) {
-        // requester만 삭제 가능
-        if (matching.requesterProfile.user.id!! != requesterUserId) {
-            throw CustomException(ErrorCode.MATCHING_FORBIDDEN)
-        }
-
-        // REQUESTED 상태만 삭제 가능
-        if (matching.status != MatchingStatus.REQUESTED) {
-            throw CustomException(ErrorCode.MATCHING_ALREADY_RESPONDED)
-        }
-    }
-
-
     private fun publishMatchingUpdatedAccepted(
         requesterUserId: String,
         matchingId: String,
@@ -447,7 +449,6 @@ class MatchingService(
         )
     }
 
-
     private fun publishMatchingUpdatedRejected(
         requesterUserId: String,
         matchingId: String,
@@ -458,20 +459,6 @@ class MatchingService(
             payload = MatchingUpdatedPayload(
                 matchingId = matchingId,
                 status = MatchingUpdateStatus.REJECTED,
-            )
-        )
-    }
-
-    private fun publishMatchingUpdatedCancelled(
-        receiverUserId: String,
-        matchingId: String,
-    ) {
-        outboxEventPublisher.publish(
-            userId = receiverUserId,
-            eventType = SseEventType.MATCHING_UPDATED,
-            payload = MatchingUpdatedPayload(
-                matchingId = matchingId,
-                status = MatchingUpdateStatus.CANCELLED,
             )
         )
     }

--- a/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/matching/service/MatchingService.kt
@@ -12,12 +12,11 @@ import org.appjam.smashing.domain.notification.service.NotificationService
 import org.appjam.smashing.domain.outbox.components.OutboxEventPublisher
 import org.appjam.smashing.domain.outbox.dto.MatchingAcceptNotificationCreatedPayload
 import org.appjam.smashing.domain.outbox.dto.MatchingReceivedPayload
-import org.appjam.smashing.domain.outbox.dto.MatchingRequestNotificationCreatedPayload
+import org.appjam.smashing.domain.outbox.dto.MatchingSentPayload
 import org.appjam.smashing.domain.outbox.dto.MatchingUpdatedPayload
 import org.appjam.smashing.domain.outbox.enums.MatchingUpdateStatus
 import org.appjam.smashing.domain.outbox.enums.SseEventType
 import org.appjam.smashing.domain.review.repository.GameReviewRepository
-import org.appjam.smashing.domain.user.entity.User
 import org.appjam.smashing.domain.user.entity.UserSportProfile
 import org.appjam.smashing.domain.user.repository.UserRepository
 import org.appjam.smashing.domain.user.repository.UserSportProfileRepository
@@ -29,6 +28,7 @@ import org.appjam.smashing.global.util.TimeUtils
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId
 
@@ -48,74 +48,118 @@ class MatchingService(
         requesterUserId: String,
         receiverProfileId: String,
     ) {
-        val receiverProfile = findReceiverProfile(receiverProfileId)
+        val now = TimeUtils.nowOffsetDateTime().toLocalDateTime()
 
-        // 자기 자신에게 매칭 요청 불가
-        validateNotSelf(requesterUserId, receiverProfile.user.id!!)
+        val requesterUser = userRepository.findByIdOrNull(requesterUserId)
+            ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
-        val requesterUser = findRequesterUser(requesterUserId)
+        val receiverProfile = userSportProfileRepository.findByIdOrNull(receiverProfileId)
+            ?: throw CustomException(ErrorCode.MATCHING_RECEIVER_PROFILE_NOT_FOUND)
 
-        val sportId = receiverProfile.sport.id ?: throw CustomException(ErrorCode.BAD_REQUEST)
-        val requesterProfile = findRequesterProfileBySport(requesterUserId, sportId)
+        val receiverUser = receiverProfile.user
 
-        // 하루 (00:00 ~) 최대 3회 게임 가능
+        // 자기 자신에게 매칭 신청 불가
+        if (receiverUser.id == requesterUserId) {
+            throw CustomException(ErrorCode.MATCHING_CANNOT_REQUEST_TO_SELF)
+        }
+
+        // sport receiverProfile의 sport로 결정
+        val sport = receiverProfile.sport
+        val sportId = sport.id ?: throw CustomException(ErrorCode.SPORT_NOT_FOUND)
+
+        // requesterProfile: 동일 sport 기준
+        val requesterProfile = userSportProfileRepository.findByUserIdAndSportCode(
+            userId = requesterUserId,
+            sportCode = sport.code,
+        ) ?: throw CustomException(ErrorCode.ACTIVE_PROFILE_NOT_FOUND)
+
+        val requesterProfileId = requesterProfile.id ?: throw CustomException(ErrorCode.ACTIVE_PROFILE_NOT_FOUND)
+        val receiverProfileIdNotNull = receiverProfile.id ?: throw CustomException(ErrorCode.MATCHING_RECEIVER_PROFILE_NOT_FOUND)
+
+        // 하루 3판 제한 (RESULT_CONFIRMED 게임 기준)
         validateDailyLimit(
-            requesterUserId = requesterUserId,
-            receiverUserId = receiverProfile.user.id!!,
+            profileA = requesterProfileId,
+            profileB = receiverProfileIdNotNull,
+            sportId = sportId,
         )
 
-        // 24시간 내 진행되지 않은 매칭 요청 이력이 남아있는 경우, 동일 상대방에 대해 중복 매칭 요청 불가
-        validateNoMatchingWithin24h(
-            userA = requesterUserId,
-            userB = receiverProfile.user.id!!,
+        // 24h 쿨다운 (요청/취소/거절 기준)
+        validateCooldown(
+            profileA = requesterProfileId,
+            profileB = receiverProfileIdNotNull,
+            sportId = sportId,
+            now = now,
         )
 
         // 매칭 생성
-        val matchingId = createMatching(
-            requesterUser = requesterUser,
-            receiverUser = receiverProfile.user,
-            receiverProfile = receiverProfile,
-        )
-
-        // 신청자 해당 스포츠 리뷰 개수 조회
-        val reviewCount = countRequesterReviewsBySport(
-            requesterUserId = requesterUserId,
-            sportId = sportId,
+        val matching = matchingRepository.save(
+            Matching.createRequested(
+                requesterProfile = requesterProfile,
+                receiverProfile = receiverProfile,
+                sport = sport,
+            )
         )
 
         // 알림 생성
-        val savedNotification = notificationService.createMatchingRequested(
-            receiver = receiverProfile.user,
+        notificationService.createMatchingRequested(
+            receiver = receiverUser,
             receiverProfile = receiverProfile,
             requesterProfile = requesterProfile,
         )
 
-        val notificationCreatedAt = savedNotification.createdAt
-            .atZone(DEFAULT_ZONE_ID)
-            .toOffsetDateTime()
-            .toString()
-
-        // SSE 이벤트 발행
-        publishMatchingReceived(
-            receiverUserId = receiverProfile.user.id!!,
-            matchingId = matchingId,
+        /**
+         * TODO: 프로필 기반 리뷰 카운트로 바꿀지 결정되면 교체 필요
+         */
+        val requesterReviewCount = gameReviewRepository.countByRevieweeAndSport(
+            revieweeUserId = requesterUser.id!!,
             sportId = sportId,
-            receiverProfileId = receiverProfileId,
-            requesterProfile = requesterProfile,
-            reviewCount = reviewCount,
+        )
+        val receiverReviewCount = gameReviewRepository.countByRevieweeAndSport(
+            revieweeUserId = receiverUser.id!!,
+            sportId = sportId,
         )
 
-        // 알림 생성 이벤트 발행
-        publishMatchingRequestNotificationCreated(
-            receiverUserId = receiverProfile.user.id!!,
-            notificationId = savedNotification.id!!,
-            notificationCreatedAt = notificationCreatedAt,
-            matchingId = matchingId,
-            sportId = sportId,
-            receiverProfileId = receiverProfileId,
-            requesterProfile = requesterProfile,
+        // SSE - 상대방에게 받은 요청 실시간 반영 + 토스트
+        outboxEventPublisher.publish(
+            userId = receiverUser.id!!,
+            eventType = SseEventType.MATCHING_RECEIVED,
+            payload = MatchingReceivedPayload(
+                matchingId = matching.id!!,
+                sportCode = sport.code,
+                receiverProfileId = receiverProfileIdNotNull,
+                requester = MatchingReceivedPayload.MatchingRequesterSummary(
+                    requesterProfileId = requesterProfileId,
+                    nickname = requesterUser.nickname,
+                    gender = requesterUser.gender,
+                    tierCode = requesterProfile.tier.code,
+                    wins = requesterProfile.wins,
+                    losses = requesterProfile.losses,
+                    reviewCount = requesterReviewCount,
+                )
+            )
+        )
+
+        // SSE - 나에게 보낸 요청 실시간 반영
+        outboxEventPublisher.publish(
+            userId = requesterUser.id!!,
+            eventType = SseEventType.MATCHING_SENT,
+            payload = MatchingSentPayload(
+                matchingId = matching.id!!,
+                sportCode = sport.code,
+                receiverProfileId = receiverProfileIdNotNull,
+                receiver = MatchingSentPayload.MatchingReceiverSummary(
+                    receiverProfileId = receiverProfileIdNotNull,
+                    nickname = receiverUser.nickname,
+                    gender = receiverUser.gender,
+                    tierCode = receiverProfile.tier.code,
+                    wins = receiverProfile.wins,
+                    losses = receiverProfile.losses,
+                    reviewCount = receiverReviewCount,
+                )
+            )
         )
     }
+
 
     @Transactional
     fun acceptMatching(
@@ -136,8 +180,8 @@ class MatchingService(
             deletedAt = LocalDateTime.now(DEFAULT_ZONE_ID),
             status = MatchingStatus.REQUESTED,
             excludeMatchingId = matchingId,
-            userA = matching.requester.id!!,
-            userB = matching.receiver.id!!,
+            userA = matching.requesterProfile.user.id!!,
+            userB = matching.receiverProfile.user.id!!,
             sportId = matching.sport.id!!,
         )
 
@@ -149,13 +193,13 @@ class MatchingService(
         val receiverProfile = findUserProfileBySport(receiverUserId, matching.sport.id!!)
 
         val requesterProfile = findUserProfileBySport(
-            userId = matching.requester.id!!,
+            userId = matching.requesterProfile.user.id!!,
             sportId = matching.sport.id!!,
         )
 
         // 알림 생성
         val savedNotification = notificationService.createMatchingAccepted(
-            receiver = matching.requester,
+            receiver = matching.requester!!,
             receiverProfile = requesterProfile,
             acceptorProfile = receiverProfile,
         )
@@ -168,13 +212,13 @@ class MatchingService(
 
         // SSE 이벤트 발행
         publishMatchingUpdatedAccepted(
-            requesterUserId = matching.requester.id!!,
+            requesterUserId = matching.requesterProfile.user.id!!,
             matchingId = matchingId,
         )
 
         // 알림 생성 이벤트 발행
         publishMatchingAcceptNotificationCreated(
-            requesterUserId = matching.requester.id!!,
+            requesterUserId = matching.requesterProfile.user.id!!,
             notificationId = savedNotification.id!!,
             notificationCreatedAt = notificationCreatedAt,
             matchingId = matchingId,
@@ -204,7 +248,7 @@ class MatchingService(
 
         // SSE 이벤트 발행
         publishMatchingUpdatedRejected(
-            requesterUserId = matching.requester.id!!,
+            requesterUserId = matching.requesterProfile.user.id!!,
             matchingId = matchingId,
         )
     }
@@ -228,7 +272,7 @@ class MatchingService(
 
         // SSE 이벤트 발행
         publishMatchingUpdatedCancelled(
-            receiverUserId = matching.receiver.id!!,
+            receiverUserId = matching.receiverProfile.user.id!!,
             matchingId = matchingId,
         )
     }
@@ -303,48 +347,58 @@ class MatchingService(
         )
     }
 
-    private fun findReceiverProfile(
-        receiverProfileId: String
-    ) = userSportProfileRepository.findByIdFetchAll(receiverProfileId)
-        ?: throw CustomException(ErrorCode.MATCHING_RECEIVER_PROFILE_NOT_FOUND)
-
-    private fun findRequesterUser(
-        requesterUserId: String
-    ) = userRepository.findByIdOrNull(requesterUserId)
-        ?: throw CustomException(ErrorCode.MATCHING_REQUESTER_NOT_FOUND)
-
-    private fun findRequesterProfileBySport(
-        requesterUserId: String,
-        sportId: Long
-    ) = userSportProfileRepository.findByUserIdAndSportIdFetch(requesterUserId, sportId)
-        ?: throw CustomException(ErrorCode.MATCHING_REQUESTER_NOT_FOUND)
-
-    private fun validateNotSelf(
-        requesterUserId: String,
-        receiverUserId: String
+    private fun validateDailyLimit(
+        profileA: String,
+        profileB: String,
+        sportId: Long,
     ) {
-        if (requesterUserId == receiverUserId) {
-            throw CustomException(ErrorCode.MATCHING_CANNOT_REQUEST_TO_SELF)
+        val zone = TimeUtils.DEFAULT_ZONE_ID
+        val today = LocalDate.now(zone)
+        val startOfDay = today.atStartOfDay()
+        val endOfDay = today.plusDays(1).atStartOfDay()
+
+        val confirmedCount = gameRepository.countConfirmedGamesTodayBetweenProfiles(
+            profileA = profileA,
+            profileB = profileB,
+            sportId = sportId,
+            startOfDay = startOfDay,
+            endOfDay = endOfDay,
+        )
+
+        if (confirmedCount >= 3L) {
+            throw CustomException(ErrorCode.MATCHING_DAILY_LIMIT_EXCEEDED)
         }
     }
 
-    private fun validateDailyLimit(
-        requesterUserId: String,
-        receiverUserId: String
+    private fun validateCooldown(
+        profileA: String,
+        profileB: String,
+        sportId: Long,
+        now: LocalDateTime,
     ) {
-        val now = LocalDateTime.now(DEFAULT_ZONE_ID)
-        val startOfDay = now.toLocalDate().atStartOfDay()
+        val latest = matchingRepository.findLatestForCooldown(
+            profileA = profileA,
+            profileB = profileB,
+            sportId = sportId,
+        ) ?: return
 
-        // 하루 확정 게임 갯수 조회
-        val todayConfirmedGames = gameRepository.countTodayConfirmedGamesBetweenUsers(
-            startAt = startOfDay,
-            userA = requesterUserId,
-            userB = receiverUserId,
-        )
+        val status = runCatching { MatchingStatus.valueOf(latest.status) }
+            .getOrElse { return }
 
-        // 하루 최대 3회 제한
-        if (todayConfirmedGames >= 3L) {
-            throw CustomException(ErrorCode.MATCHING_DAILY_LIMIT_EXCEEDED)
+        when (status) {
+            MatchingStatus.REQUESTED -> {
+                val until = latest.createdAt.plusHours(24)
+                if (now.isBefore(until)) throw CustomException(ErrorCode.MATCHING_PENDING_EXISTS)
+            }
+
+            MatchingStatus.CANCELLED,
+            MatchingStatus.REJECTED -> {
+                val base = latest.respondedAt ?: latest.createdAt
+                val until = base.plusHours(24)
+                if (now.isBefore(until)) throw CustomException(ErrorCode.MATCHING_PENDING_EXISTS)
+            }
+
+            else -> Unit
         }
     }
 
@@ -353,7 +407,7 @@ class MatchingService(
         receiverUserId: String,
     ) {
         // receiver만 거절 가능
-        if (matching.receiver.id!! != receiverUserId) {
+        if (matching.receiverProfile.user.id!! != receiverUserId) {
             throw CustomException(ErrorCode.MATCHING_FORBIDDEN)
         }
 
@@ -368,7 +422,7 @@ class MatchingService(
         requesterUserId: String,
     ) {
         // requester만 삭제 가능
-        if (matching.requester.id!! != requesterUserId) {
+        if (matching.requesterProfile.user.id!! != requesterUserId) {
             throw CustomException(ErrorCode.MATCHING_FORBIDDEN)
         }
 
@@ -378,75 +432,6 @@ class MatchingService(
         }
     }
 
-    private fun validateNoMatchingWithin24h(
-        userA: String,
-        userB: String,
-    ) {
-        val now = LocalDateTime.now(DEFAULT_ZONE_ID)
-        val since = now.minusHours(24)
-
-        val exists = matchingRepository.existsUnconfirmedMatchingBetweenUsersSinceRaw(
-            startAt = since,
-            userA = userA,
-            userB = userB,
-        ) == 1L
-
-        if (exists) {
-            throw CustomException(ErrorCode.MATCHING_PENDING_EXISTS)
-        }
-    }
-
-
-    private fun createMatching(
-        requesterUser: User,
-        receiverUser: User,
-        receiverProfile: UserSportProfile,
-    ): String {
-        val matching = matchingRepository.save(
-            Matching.createRequested(
-                requester = requesterUser,
-                receiver = receiverUser,
-                sport = receiverProfile.sport,
-            )
-        )
-        return requireNotNull(matching.id)
-    }
-
-    private fun countRequesterReviewsBySport(
-        requesterUserId: String,
-        sportId: Long,
-    ): Long = gameReviewRepository.countByRevieweeAndSport(
-        revieweeUserId = requesterUserId,
-        sportId = sportId,
-    )
-
-    private fun publishMatchingReceived(
-        receiverUserId: String,
-        matchingId: String,
-        sportId: Long,
-        receiverProfileId: String,
-        requesterProfile: UserSportProfile,
-        reviewCount: Long,
-    ) {
-        outboxEventPublisher.publish(
-            userId = receiverUserId,
-            eventType = SseEventType.MATCHING_RECEIVED,
-            payload = MatchingReceivedPayload(
-                matchingId = matchingId,
-                sportId = sportId,
-                receiverProfileId = receiverProfileId,
-                requester = MatchingReceivedPayload.MatchingRequesterSummary(
-                    userId = requesterProfile.user.id!!,
-                    nickname = requesterProfile.user.nickname,
-                    gender = requesterProfile.user.gender,
-                    tierCode = requesterProfile.tier.code,
-                    wins = requesterProfile.wins,
-                    losses = requesterProfile.losses,
-                    reviewCount = reviewCount,
-                )
-            )
-        )
-    }
 
     private fun publishMatchingUpdatedAccepted(
         requesterUserId: String,
@@ -462,33 +447,6 @@ class MatchingService(
         )
     }
 
-    private fun publishMatchingRequestNotificationCreated(
-        receiverUserId: String,
-        notificationId: String,
-        notificationCreatedAt: String,
-        matchingId: String,
-        sportId: Long,
-        receiverProfileId: String,
-        requesterProfile: UserSportProfile,
-    ) {
-        outboxEventPublisher.publish(
-            userId = receiverUserId,
-            eventType = SseEventType.MATCHING_REQUEST_NOTIFICATION_CREATED,
-            payload = MatchingRequestNotificationCreatedPayload(
-                notificationId = notificationId,
-                notificationType = NotificationType.MATCHING_REQUESTED,
-                notificationCreatedAt = notificationCreatedAt,
-                matchingId = matchingId,
-                sportId = sportId,
-                receiverProfileId = receiverProfileId,
-                requester = MatchingRequestNotificationCreatedPayload.RequesterSummary(
-                    userId = requesterProfile.user.id!!,
-                    nickname = requesterProfile.user.nickname,
-                    tierCode = requesterProfile.tier.code,
-                )
-            )
-        )
-    }
 
     private fun publishMatchingUpdatedRejected(
         requesterUserId: String,
@@ -523,7 +481,7 @@ class MatchingService(
         receiverUserId: String
     ) {
         // receiver만 수락 가능
-        if (matching.receiver.id!! != receiverUserId) {
+        if (matching.receiverProfile.user.id!! != receiverUserId) {
             throw CustomException(ErrorCode.MATCHING_FORBIDDEN)
         }
 
@@ -569,7 +527,7 @@ class MatchingService(
     }
 
     // 삭제 예정
-    companion object {
+    companion object { // TODO: DEFAULT 부분 constants로 통일 예정 모두 삭제
         val DEFAULT_ZONE_ID = ZoneId.of("Asia/Seoul")
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/entity/Notification.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/entity/Notification.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.*
 import org.appjam.smashing.domain.common.entity.BaseEntity
 import org.appjam.smashing.domain.game.entity.Game
 import org.appjam.smashing.domain.game.entity.GameResultSubmission
+import org.appjam.smashing.domain.notification.enums.NotificationType
 import org.appjam.smashing.domain.user.entity.User
 import org.appjam.smashing.domain.user.entity.UserSportProfile
 import org.hibernate.annotations.Comment
@@ -15,7 +16,10 @@ import org.hibernate.annotations.SQLRestriction
 @Table(
     indexes = [
         Index(name = "idx_notification_user_id", columnList = "user_id"),
-        Index(name = "idx_notification_template_id", columnList = "notification_template_id"),
+        Index(name = "idx_notification_type", columnList = "type"),
+        Index(name = "idx_notification_sender_user_id", columnList = "sender_user_id"),
+        Index(name = "idx_notification_sender_profile_id", columnList = "sender_profile_id"),
+        Index(name = "idx_notification_sport_code", columnList = "sport_code"),
     ]
 )
 @Comment("알림 정보")
@@ -28,17 +32,42 @@ class Notification(
     @Comment("알림 IDX")
     val id: String? = null,
 
-    @Column(nullable = false, length = 500)
+    @Enumerated(EnumType.STRING)
+    @Column(length = 50)
+    @Comment("알림 타입")
+    val type: NotificationType? = null,
+
+    @Column(length = 100)
+    @Comment("알림 제목")
+    val title: String? = null,
+
+    @Column(length = 500)
+    @Comment("알림 내용")
+    val content: String? = null,
+
+    @Column(name = "sport_code", length = 50)
+    @Comment("스포츠 코드")
+    val sportCode: String? = null,
+
+    @Column(name = "sender_user_id", length = 13)
+    @Comment("발신자 유저 IDX")
+    val senderUserId: String? = null,
+
+    @Column(name = "sender_profile_id", length = 13)
+    @Comment("발신자 유저-스포츠 프로필 IDX")
+    val senderProfileId: String? = null,
+
+    @Column(length = 500)
     @Comment("알림 치환 파라미터(JSON)")
-    val params: String,
+    val params: String? = null, // TODO: 추후 알림 모두 리팩토링 시 삭제
 
     @Column(nullable = false)
     @Comment("알림 읽음 여부")
     var isRead: Boolean = false,
 
-    @Column(nullable = false, length = 500)
-    @Comment("알림 연결 URL(라우팅 경로)")
-    val linkUrl: String,
+    @Column(length = 500)
+    @Comment("알림 연결 URL")
+    val linkUrl: String? = null, // TODO: 추후 알림 모두 리팩토링 시 삭제
 
     @Column(nullable = false, length = 13)
     @Comment("수신자 유저-스포츠 프로필 IDX")
@@ -46,11 +75,10 @@ class Notification(
 
     @Column(length = 10)
     @Comment("발신자 유저 닉네임")
-    val senderNickname: String,
+    val senderNickname: String? = null, // TODO: senderUserId 기반 조회로 대체 후 제거
 
-    @Column(nullable = false)
     @Comment("수신 스포츠 IDX")
-    val receiverSportId: Long,
+    val receiverSportId: Long? = null, // TODO: 모두 리팩토링시 제거 예정
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(
@@ -62,31 +90,41 @@ class Notification(
     val user: User,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(
-        name = "notification_template_id",
-        nullable = false,
-        foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT)
-    )
+    @JoinColumn(name = "notification_template_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
     @Comment("템플릿 IDX")
-    val notificationTemplate: NotificationTemplate,
+    val notificationTemplate: NotificationTemplate? = null, // TODO: 알림 리팩토링 완료 후 제거
 ) : BaseEntity() {
 
+
     companion object {
+
+        /**
+         * 매칭 신청 도착 알림 생성
+         */
         fun createMatchingRequested(
             receiver: User,
             receiverProfile: UserSportProfile,
-            template: NotificationTemplate,
             requesterProfile: UserSportProfile,
-        ) = Notification(
-            params = """{"sportName":"${receiverProfile.sport.name}","requesterNickname":"${requesterProfile.user.nickname}","requesterTierName":"${requesterProfile.tier.name}"}""",
-            isRead = false,
-                linkUrl = "/api/v1/users/me/matchings/received",
+        ): Notification {
+            val sportName = receiverProfile.sport.name
+            val sportCode = receiverProfile.sport.code
+            val requesterNickname = requesterProfile.user.nickname
+
+            val title = "[$sportName] 매칭 신청이 도착했어요"
+            val content = "${requesterNickname}님으로부터 매칭 신청이 도착했어요! 지금 확인해볼까요?"
+
+            return Notification(
+                type = NotificationType.MATCHING_REQUESTED,
+                title = title,
+                content = content,
+                sportCode = sportCode,
+                senderUserId = requesterProfile.user.id!!,
+                senderProfileId = requesterProfile.id!!,
+                isRead = false,
                 receiverProfileId = receiverProfile.id!!,
-                receiverSportId = receiverProfile.sport.id!!,
-                senderNickname = requesterProfile.user.nickname,
                 user = receiver,
-                notificationTemplate = template,
             )
+        }
 
         fun createMatchingRequestAccepted(
             receiver: User,

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/entity/NotificationTemplate.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/entity/NotificationTemplate.kt
@@ -6,7 +6,7 @@ import org.hibernate.annotations.Comment
 
 @Entity
 @Comment("알림 템플릿 정보")
-class NotificationTemplate(
+class NotificationTemplate( // TODO: 알림 전체 리팩토링 후 엔티티 삭제 예정
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Comment("템플릿 IDX")

--- a/src/main/kotlin/org/appjam/smashing/domain/notification/service/NotificationService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/notification/service/NotificationService.kt
@@ -29,15 +29,11 @@ class NotificationService(
         receiver: User,
         receiverProfile: UserSportProfile,
         requesterProfile: UserSportProfile,
-    ): Notification {
-        val template = notificationTemplateRepository.findByType(NotificationType.MATCHING_REQUESTED)
-            ?: throw CustomException(ErrorCode.NOTIFICATION_TEMPLATE_NOT_FOUND)
-
-        return notificationRepository.save(
+    ) {
+        notificationRepository.save(
             Notification.createMatchingRequested(
                 receiver = receiver,
                 receiverProfile = receiverProfile,
-                template = template,
                 requesterProfile = requesterProfile,
             )
         )

--- a/src/main/kotlin/org/appjam/smashing/domain/outbox/dto/SsePayload.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/outbox/dto/SsePayload.kt
@@ -71,28 +71,6 @@ data class MatchingUpdatedPayload(
 ) : SsePayload
 
 /**
- * 매칭 신청 알림 생성
- * - 상대가 나에게 매칭을 신청한 순간 알림 생성
- */
-data class MatchingRequestNotificationCreatedPayload(
-    override val type: String = SseEventType.MATCHING_REQUEST_NOTIFICATION_CREATED.eventName,
-    val notificationId: String,
-    val notificationType: NotificationType,
-    val notificationCreatedAt: String,
-    val matchingId: String,
-    val sportId: Long,
-    val receiverProfileId: String,
-    val requester: RequesterSummary,
-) : SsePayload {
-
-    data class RequesterSummary(
-        val userId: String,
-        val nickname: String,
-        val tierCode: TierCode,
-    )
-}
-
-/**
  * 매칭 수락 알림 생성
  * - 상대가 나의 매칭을 수락한 순간 알림 생성
  */

--- a/src/main/kotlin/org/appjam/smashing/domain/outbox/dto/SsePayload.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/outbox/dto/SsePayload.kt
@@ -13,6 +13,52 @@ sealed interface SsePayload {
 }
 
 /**
+ * 매칭 관리 - 받은 요청
+ * - 내가 상대에게 매칭을 신청한 순간 상대에게 카드 추가 SSE 이벤트 발행
+ */
+data class MatchingReceivedPayload(
+    override val type: String = SseEventType.MATCHING_RECEIVED.eventName,
+    val matchingId: String,
+    val sportCode: String,
+    val receiverProfileId: String,
+    val requester: MatchingRequesterSummary,
+) : SsePayload {
+
+    data class MatchingRequesterSummary(
+        val requesterProfileId: String, // TODO: 유저 정보 조회시 profileid 값 논의 필요
+        val nickname: String,
+        val gender: Gender,
+        val tierCode: TierCode,
+        val wins: Int,
+        val losses: Int,
+        val reviewCount: Long,
+    )
+}
+
+/**
+ * 매칭 관리 - 보낸 요청
+ * - 내가 상대에게 매칭을 신청한 순간 나에게 카드 추가 SSE 이벤트 발행
+ */
+data class MatchingSentPayload(
+    override val type: String = SseEventType.MATCHING_SENT.eventName,
+    val matchingId: String,
+    val sportCode: String,
+    val receiverProfileId: String,
+    val receiver: MatchingReceiverSummary,
+) : SsePayload {
+
+    data class MatchingReceiverSummary(
+        val receiverProfileId: String,
+        val nickname: String,
+        val gender: Gender,
+        val tierCode: TierCode,
+        val wins: Int,
+        val losses: Int,
+        val reviewCount: Long,
+    )
+}
+
+/**
  * 매칭 상태 변경
  * - 보낸 요청 / 매칭확정 / 요청삭제
  * - 상대가 내 요청을 ACCEPT/REJECT 하는 순간
@@ -23,29 +69,6 @@ data class MatchingUpdatedPayload(
     val matchingId: String,
     val status: MatchingUpdateStatus,
 ) : SsePayload
-
-/**
- * 매칭관리 - 받은 요청
- * - 상대가 나에게 매칭을 신청한 순간
- */
-data class MatchingReceivedPayload(
-    override val type: String = SseEventType.MATCHING_RECEIVED.eventName,
-    val matchingId: String,
-    val sportId: Long,
-    val receiverProfileId: String,
-    val requester: MatchingRequesterSummary,
-) : SsePayload {
-
-    data class MatchingRequesterSummary(
-        val userId: String,
-        val nickname: String,
-        val gender: Gender,
-        val tierCode: TierCode,
-        val wins: Int,
-        val losses: Int,
-        val reviewCount: Long,
-    )
-}
 
 /**
  * 매칭 신청 알림 생성

--- a/src/main/kotlin/org/appjam/smashing/domain/outbox/dto/SsePayload.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/outbox/dto/SsePayload.kt
@@ -60,9 +60,7 @@ data class MatchingSentPayload(
 
 /**
  * 매칭 상태 변경
- * - 보낸 요청 / 매칭확정 / 요청삭제
- * - 상대가 내 요청을 ACCEPT/REJECT 하는 순간
- * - 상대가 보낸 요청을 CANCELLED 하는 순간
+ * - 매칭 요청 취소 / 매칭 요청 거절 시 카드 삭제 SSE 이벤트 발행
  */
 data class MatchingUpdatedPayload(
     override val type: String = SseEventType.MATCHING_UPDATED.eventName,

--- a/src/main/kotlin/org/appjam/smashing/domain/outbox/enums/SseEventType.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/outbox/enums/SseEventType.kt
@@ -3,8 +3,13 @@ package org.appjam.smashing.domain.outbox.enums
 enum class SseEventType(
     val eventName: String
 ) {
-    // 내가 요청 받음
+
+    // 받은 매칭 요청 카드 실시간 추가
     MATCHING_RECEIVED("matching.received"),
+
+    // 보낸 매칭 요청 카드 실시간 추가
+    MATCHING_SENT("matching.sent"),
+
 
     // 상대가 요청을 수락/거절/삭제
     MATCHING_UPDATED("matching.updated"),

--- a/src/main/kotlin/org/appjam/smashing/domain/outbox/enums/SseEventType.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/outbox/enums/SseEventType.kt
@@ -14,12 +14,6 @@ enum class SseEventType(
     MATCHING_UPDATED("matching.updated"),
 
 
-    // 알림 관련 생성 / 변경 사항
-    NOTIFICATION_CREATED("notification.created"),
-
-    // 매칭 요청 알림 생성
-    MATCHING_REQUEST_NOTIFICATION_CREATED("matching.request.notification.created"),
-
     // 매칭 수락 알림 생성
     MATCHING_ACCEPT_NOTIFICATION_CREATED("matching.accept.notification.created"),
 

--- a/src/main/kotlin/org/appjam/smashing/domain/outbox/enums/SseEventType.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/outbox/enums/SseEventType.kt
@@ -10,9 +10,9 @@ enum class SseEventType(
     // 보낸 매칭 요청 카드 실시간 추가
     MATCHING_SENT("matching.sent"),
 
-
-    // 상대가 요청을 수락/거절/삭제
+    // 매칭 엔티티 상태 업데이트 실시간 반영 (삭제(취소))
     MATCHING_UPDATED("matching.updated"),
+
 
     // 알림 관련 생성 / 변경 사항
     NOTIFICATION_CREATED("notification.created"),

--- a/src/main/kotlin/org/appjam/smashing/global/util/TimeConstants.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/util/TimeConstants.kt
@@ -8,7 +8,7 @@ object TimeUtils {
     /*
      * 기본 타임존 상수
      */
-    val DEFAULT_ZONE_ID: ZoneId = ZoneId.of("Asia/Seoul") // TODO: 이후 사용자 기준 타임존으로 분리 예정
+    val DEFAULT_ZONE_ID: ZoneId = ZoneId.of("Asia/Seoul")
 
     /*
      * LocalDateTime -> OffsetDateTime 변환


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #169
- closes #184 
- closes #176 

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 매칭 신청 API에 대한 리팩토링을 진행합니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 매칭 신청 API 리팩토링
- [x] 보낸 매칭 요청 취소 API 리팩토링
- [x] 매칭 요청 거절 API 리팩토링

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 매칭 신청 API
<img width="1170" height="1192" alt="image" src="https://github.com/user-attachments/assets/f5bef6ed-9b5b-4128-b728-70156b606a6f" />
<img width="1366" height="1106" alt="image" src="https://github.com/user-attachments/assets/69b8f9fe-93ec-422c-adcf-01a56642a7e8" />

- 매칭 취소 API
<img width="1446" height="1226" alt="image" src="https://github.com/user-attachments/assets/81d685f9-10bf-4611-b681-f8361bf3bce6" />
<img width="1902" height="1534" alt="image" src="https://github.com/user-attachments/assets/eab2dabc-7dce-4cf2-be5b-01104f72dadd" />

- 매칭 요청 거절 API
<img width="1244" height="1002" alt="image" src="https://github.com/user-attachments/assets/a57b947c-8c60-42d7-9053-c41bf892fbff" />
<img width="1282" height="1112" alt="image" src="https://github.com/user-attachments/assets/ec471df4-91c3-49e5-b659-545926676505" />

## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
논의해야할 사항들이 조금 있습니다..!

1) 알림 템플릿 엔티티를 삭제, 알림 엔티티로만 가져가려 합니다. 기존에 알림 템플릿을 일일히 db에서 조회 후 params와 대조해 서버에서 렌더링하는 방식이 효율적이지 못하다고 판단, title과 content를 그대로 db에 저장하는 방식으로 가져가면 어떨까 합니다. 기존 params의 경우 알림에서 params 만 따로 처리하는 경우가 존재할까 싶어 분리하는 방식으로 결정했지만, 해당 기획이 존재하지 않고 기존의 방식이 많이 비효율적이라는 판단에 현재 PR의 방식으로 수정하는 것이 어떨까 하였습니다.

2) 매칭 엔티티에서 user가 아닌 usersportprofile을 가져가려합니다. 물론 user+sport 조합으로도 충분히 가능하지만, 현재 시점까지의 저희 기능을 보았을 때 profile -> matching으로 모두 이루어지고 있어 이렇게 하는 것이 모든 기능에서 복잡도를 낮출 수 있는 방법이라 생각되어 이렇게 수정해보았습니다!

3) 유저의 정보 조회시 현재 userid로 조회되고 있지만, userprofileid로 조회하는 것으로 바꾸는 것을 논의드리고 싶습니다. 현재 기능상으로 유저의 정보 조회시 userid의 정보가 아니라, userprofile 의 정보가 조회되는 것이 더 맞는 방향 같아 profileid로 조회하는 것을 논의 드리고 싶어요! 해당 유저 페이지 정보로 리다이렉트되는 부분들 중 sse나 알림을 통해 리다이렉트되는 부분들이 있어 이부분을 한번 맞추고 가면 좋을 것같습니다.

4) 사용자의 타임존을 불러오는 모든 기준을 기존에 다양한 방식이 섞여있었지만 (서비스 코드에 상수로 삽입, util로 불러오기, 설정 값 불러오기 등등 ) 이것을 timeutil 함수 하나로 불러오는 것으로 통일하는 것을 논의드리고 싶습니다!

5) 앱잼 기간에 논의되었던 tier, sport를 code로 통일하는 부분을 적용하였습니다. 이부분 한번 다른 기능 구현에서도 유의깊게 체크해주시면 좋을 것같습니다 ☺️








