### PR TITLE
refac: #208 신고 정책 수정

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUsersLeaderBoardResponse.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/dto/response/OtherUsersLeaderBoardResponse.kt
@@ -9,7 +9,7 @@ data class OtherUsersLeaderBoardResponse(
 ) {
     data class OtherUsers(
         val rank: Int,
-        val userId: String,
+        val userProfileId: String,
         val nickname: String,
         val tierCode: TierCode,
         val lp: Int,
@@ -20,7 +20,7 @@ data class OtherUsersLeaderBoardResponse(
                 rank: Int,
             ) = OtherUsers(
                 rank = rank,
-                userId = u.user.id!!,
+                userProfileId = u.id!!,
                 nickname = u.user.nickname,
                 tierCode = u.tier.code,
                 lp = u.lp,

--- a/src/main/kotlin/org/appjam/smashing/domain/user/entity/User.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/entity/User.kt
@@ -79,6 +79,8 @@ class User(
         this.restrictionEndDate = LocalDateTime.now().plusDays(durationDays)
     }
 
+    fun isRestricted(now: LocalDateTime = LocalDateTime.now()): Boolean = restrictionEndDate?.isAfter(now) ?: false
+
     companion object {
         const val DELETED_USER_NICKNAME = "알 수 없음"
 

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepository.kt
@@ -97,24 +97,6 @@ interface UserSportProfileRepository : JpaRepository<UserSportProfile, String>, 
 
     fun existsByUserIdAndSportId(userId: String, sportId: Long): Boolean
 
-    @Query(
-        """
-            select usp
-            from UserSportProfile usp
-            join fetch usp.user u
-            join fetch usp.sport s
-            join fetch usp.tier t
-            where u.region = :region
-              and s.id = :sportId
-            order by usp.lp desc, u.nickname asc 
-            limit 30
-        """
-    )
-    fun findAllByRegionAndSportOrderByLp(
-        region: String,
-        sportId: Long,
-    ): List<UserSportProfile>
-
     fun findByUserIdAndSportCode(
         userId: String,
         sportCode: String

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepositoryCustom.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepositoryCustom.kt
@@ -3,6 +3,7 @@ package org.appjam.smashing.domain.user.repository
 import org.appjam.smashing.domain.user.dto.projection.OtherUserRecommendationProjection
 import org.appjam.smashing.domain.user.dto.projection.OtherUserRegionProjection
 import org.appjam.smashing.domain.user.dto.projection.OtherUserSearchProjection
+import org.appjam.smashing.domain.user.entity.UserSportProfile
 import org.appjam.smashing.domain.user.enums.Gender
 import org.appjam.smashing.global.common.dto.CommonCursorRequest
 import org.appjam.smashing.global.common.dto.CursorPageResponse
@@ -64,4 +65,13 @@ interface UserSportProfileRepositoryCustom {
         snapshotAt: OffsetDateTime,
         blockIds: List<String>,
     ): CursorPageResponse<OtherUserRegionProjection>
+
+    /**
+     * [추가 제재]
+     * - 신고로 인해 정지당한 유저는 제외
+     */
+    fun findAllByRegionAndSportOrderByLp(
+        region: String,
+        sportId: Long,
+    ): List<UserSportProfile>
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepositoryCustomImpl.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepositoryCustomImpl.kt
@@ -137,13 +137,17 @@ class UserSportProfileRepositoryCustomImpl(
             reviewCountExpression
         )
 
+        val now = LocalDateTime.now()
+
         val where = BooleanBuilder()
             .and(user.region.eq(region))
             .and(userSportProfile.sport.id.eq(sportId))
             .and(user.id.ne(userId))
             .and(user.createdAt.loe(snapshotLocal))
+            // 신고 필터링
+            .and(user.restrictionEndDate.isNull.or(user.restrictionEndDate.before(now)))
 
-        // 차단 관계 유저 필터링
+        // 차단 필터링
         if (blockIds.isNotEmpty()) {
             where.and(user.id.notIn(blockIds))
         }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepositoryCustomImpl.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/repository/UserSportProfileRepositoryCustomImpl.kt
@@ -6,9 +6,12 @@ import com.querydsl.jpa.JPAExpressions
 import com.querydsl.jpa.impl.JPAQueryFactory
 import org.appjam.smashing.domain.review.entity.QGameReview
 import org.appjam.smashing.domain.review.entity.QGameReview.Companion.gameReview
+import org.appjam.smashing.domain.sport.entity.QSport.Companion.sport
+import org.appjam.smashing.domain.tier.entity.QTier.Companion.tier
 import org.appjam.smashing.domain.user.dto.projection.*
 import org.appjam.smashing.domain.user.entity.QUser.Companion.user
 import org.appjam.smashing.domain.user.entity.QUserSportProfile.Companion.userSportProfile
+import org.appjam.smashing.domain.user.entity.UserSportProfile
 import org.appjam.smashing.domain.user.enums.Gender
 import org.appjam.smashing.global.common.dto.CommonCursorRequest
 import org.appjam.smashing.global.common.dto.CursorPageResponse
@@ -192,5 +195,31 @@ class UserSportProfileRepositoryCustomImpl(
             pageSize = size,
             cursorCodec = cursorCodec,
         )
+    }
+
+    override fun findAllByRegionAndSportOrderByLp(
+        region: String,
+        sportId: Long,
+    ): List<UserSportProfile> {
+        val now = LocalDateTime.now()
+
+        return queryFactory
+            .selectFrom(userSportProfile)
+            .join(userSportProfile.user, user).fetchJoin()
+            .join(userSportProfile.sport, sport).fetchJoin()
+            .join(userSportProfile.tier, tier).fetchJoin()
+            .where(
+                // 기본 필터링
+                user.region.eq(region),
+                userSportProfile.sport.id.eq(sportId),
+                /// 신고 필터링
+                user.restrictionEndDate.isNull.or(user.restrictionEndDate.before(now))
+            )
+            .orderBy(
+                userSportProfile.lp.desc(),
+                user.nickname.asc()
+            )
+            .limit(30)
+            .fetch()
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -164,22 +164,16 @@ class UserService(
         val otherUser = userRepository.findByIdOrNull(otherUserProfile.user.id!!)
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
-        // 제재1 - 상호 차단 유저 프로필 검색 불가
-        val blockIds = blockRepository.findAllRelatedBlockIds(userId)
-        if (blockIds.contains(otherUser.id!!)) {
-            throw CustomException(ErrorCode.BLOCKED_RELATION)
-        }
-
-        // 제재2 - 신고 제한있는 유저 프로필 검색 불가
-        val now = LocalDateTime.now()
-        if (otherUser.restrictionEndDate?.isAfter(now) == true) {
-            throw CustomException(ErrorCode.REPORT_RESTRICTED_USER)
-        }
-
-        val myInfo = getMyInfoAndActiveProfile(userId)
+        // 노출 제한이 있는 유저인지 검사
+        validateUserAccess(
+            userId = userId,
+            otherUser = otherUser,
+        )
 
         // 다른 유저의 조회할 프로필 선택
         val allProfiles = userSportProfileRepository.findAllByUserIdOrderBySportName(otherUser.id!!)
+
+        val myInfo = getMyInfoAndActiveProfile(userId)
 
         val selectedProfile = if (sportCode == null) {
             allProfiles.find { myInfo.activeProfile.sport.code == it.sport.code }
@@ -649,6 +643,23 @@ class UserService(
             activeProfile = activeProfile,
         )
     }
+
+    private fun validateUserAccess(
+        userId: String,
+        otherUser: User,
+    ) {
+        // 1. 차단 관계 확인
+        val blockIds = blockRepository.findAllRelatedBlockIds(userId)
+        if (blockIds.contains(otherUser.id)) {
+            throw CustomException(ErrorCode.BLOCKED_RELATION)
+        }
+
+        // 2. 신고 제재 확인
+        if (otherUser.isRestricted()) {
+            throw CustomException(ErrorCode.REPORT_RESTRICTED_USER)
+        }
+    }
+
 
     companion object {
         private val NICKNAME_VALID_REGEX = Regex("^[a-zA-Z0-9가-힣]*$")

--- a/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/user/service/UserService.kt
@@ -164,10 +164,16 @@ class UserService(
         val otherUser = userRepository.findByIdOrNull(otherUserProfile.user.id!!)
             ?: throw CustomException(ErrorCode.USER_NOT_FOUND)
 
-        // 제재 - 상호 차단 유저 프로필 검색 불가
+        // 제재1 - 상호 차단 유저 프로필 검색 불가
         val blockIds = blockRepository.findAllRelatedBlockIds(userId)
         if (blockIds.contains(otherUser.id!!)) {
             throw CustomException(ErrorCode.BLOCKED_RELATION)
+        }
+
+        // 제재2 - 신고 제한있는 유저 프로필 검색 불가
+        val now = LocalDateTime.now()
+        if (otherUser.restrictionEndDate?.isAfter(now) == true) {
+            throw CustomException(ErrorCode.REPORT_RESTRICTED_USER)
         }
 
         val myInfo = getMyInfoAndActiveProfile(userId)

--- a/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
+++ b/src/main/kotlin/org/appjam/smashing/global/exception/ErrorCode.kt
@@ -117,6 +117,7 @@ enum class ErrorCode(
     REPORT_ALREADY_EXISTS(HttpStatus.CONFLICT, "REPORT-003", "해당 유저는 이미 신고한 상대입니다."),
     REPORT_REASON_REQUIRED(HttpStatus.BAD_REQUEST, "REPORT-004", "신고 유형이 '기타'인 경우 상세 사유는 필수입니다."),
     REPORT_REASON_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "REPORT-005", "신고 유형이 '기타'가 아닌 경우 상세 사유는 입력 불가입니다."),
+    REPORT_RESTRICTED_USER(HttpStatus.FORBIDDEN, "REPORT-006", "신고 제재를 당한 유저입니다."),
 
     // Domain - Block
     BLOCKED_NOT_FOUND(HttpStatus.NOT_FOUND, "BLOCK-001", "차단 대상 유저를 찾을 수 없습니다."),


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #208

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 신고 정책을 수정합니다. 
  - `사용자 지역 유저들 실력순 조회 API`에서 신고 제재를 당한 유저를 제외합니다. 
  - `다른 유저 정보 상세 조회 API`에서 신고 당한 유저는 에러 케이스를 추가했습니다.
  - `사용자 지역 유저들 목록 조회 API`에서 신고 당한 유저는 노출 제외합니다.
- 리팩토링 되지 않은 API를 수정합니다.
  - `사용자 지역 유저들 실력순 조회 API`의 응답값을 userProfileId로 수정합니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] `사용자 지역 유저들 실력순 조회 API` 수정
- [x] `다른 유저 정보 상세 조회 API` 수정
- [x] `사용자 지역 유저들 목록 조회 API` 수정

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- `사용자 지역 유저들 실력순 조회 API` - 신고 제재 당한 유저 노출 제외
<img width="400" src="https://github.com/user-attachments/assets/a5bf6568-b8ce-4b9b-85ab-ee8a72981ab3" />

- `다른 유저 정보 상세 조회 API` - 신고 제재 당한 유저 프로필 진입 불가

<img width="500" src="https://github.com/user-attachments/assets/a9ae9ead-9d4e-4ca4-81ea-642892638185" />

  - `사용자 지역 유저들 목록 조회 API`- 신고 당한 유저는 노출 제외

<img width="500"  src="https://github.com/user-attachments/assets/6b59c122-4d71-48a9-b749-b6b007a7703d" />


## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 아자아자!!