### PR TITLE
feat: #204 경기 72시간 만료 스케쥴러 구현

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/domain/game/entity/Game.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/entity/Game.kt
@@ -131,4 +131,8 @@ class Game(
     fun cancel() {
         resultStatus = GameStatus.CANCELED
     }
+
+    fun expire() {
+        resultStatus = GameStatus.EXPIRED
+    }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/game/enums/GameStatus.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/enums/GameStatus.kt
@@ -5,5 +5,6 @@ enum class GameStatus {
     WAITING_CONFIRMATION,     // 경기 결과 확인 대기 중
     RESULT_CONFIRMED,         // 경기 결과 확인 완료
     RESULT_REJECTED,          // 경기 결과 반려됨
-    CANCELED                  // 경기 취소됨
+    CANCELED,                 // 경기 취소됨
+    EXPIRED,                  // 경기 만료됨 (72시간 미처리)
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/repository/GameRepository.kt
@@ -2,6 +2,7 @@ package org.appjam.smashing.domain.game.repository
 
 import jakarta.persistence.LockModeType
 import org.appjam.smashing.domain.game.entity.Game
+import org.appjam.smashing.domain.game.enums.GameStatus
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
@@ -37,6 +38,16 @@ interface GameRepository : JpaRepository<Game, String>, GameRepositoryCustom {
         @Param("startOfDay") startOfDay: LocalDateTime,
         @Param("endOfDay") endOfDay: LocalDateTime,
     ): Long
+
+    @Query("""
+    select g from Game g
+    where g.resultStatus in :statuses
+    and g.createdAt <= :expiredBefore
+    """)
+    fun findAllExpiredGames(
+        @Param("statuses") statuses: List<GameStatus>,
+        @Param("expiredBefore") expiredBefore: LocalDateTime,
+    ): List<Game>
 
     fun existsByMatchingId(
         matchingId: String

--- a/src/main/kotlin/org/appjam/smashing/domain/scheduler/GameExpiryScheduler.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/scheduler/GameExpiryScheduler.kt
@@ -1,0 +1,44 @@
+package org.appjam.smashing.domain.scheduler
+
+import org.appjam.smashing.domain.game.enums.GameStatus
+import org.appjam.smashing.domain.game.repository.GameRepository
+import org.appjam.smashing.global.util.TimeUtils
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Component
+class GameExpiryScheduler(
+    private val gameRepository: GameRepository,
+) {
+    // 매 10분마다 만료된 게임 처리
+    @Scheduled(fixedDelay = 10 * 60 * 1000)
+    @Transactional
+    fun expireGames() {
+        val now = LocalDateTime.now(TimeUtils.DEFAULT_ZONE_ID)
+
+        // 72시간 경과 기준
+        val expiredBefore = now.minusHours(72)
+
+        // 만료 대상 상태
+        // - PENDING_RESULT: Host가 결과 작성 안 함
+        // - WAITING_CONFIRMATION: 상대가 확인 안 함
+        // - RESULT_REJECTED: 반려 후 Host가 재작성 안 함
+        val expiredStatuses = listOf(
+            GameStatus.PENDING_RESULT,
+            GameStatus.WAITING_CONFIRMATION,
+            GameStatus.RESULT_REJECTED,
+        )
+
+        val expiredGames = gameRepository.findAllExpiredGames(
+            statuses = expiredStatuses,
+            expiredBefore = expiredBefore,
+        )
+
+        // 만료 처리 (기록되지 않음)
+        expiredGames.forEach { game ->
+            game.expire()
+        }
+    }
+}

--- a/src/main/kotlin/org/appjam/smashing/domain/scheduler/GameExpiryScheduler.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/scheduler/GameExpiryScheduler.kt
@@ -36,7 +36,7 @@ class GameExpiryScheduler(
             expiredBefore = expiredBefore,
         )
 
-        // 만료 처리 (기록되지 않음)
+        // 만료 처리
         expiredGames.forEach { game ->
             game.expire()
         }


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #204 

## #️⃣ 요약 설명
<!-- 작업에 대한 전체적인 개요를 간단하게 작성해주세요 -->
- 기획 요구 사항 중, 경기 72시간 만료 정책에 대한 기능을 스케쥴러로 구현합니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 경기 상태 만료 추가
- [x] 경기 72시간 만료 처리 스케쥴러 구현

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 내용

## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 내용