### PR TITLE
refac: #222 SSE 이벤트 복구 처리 스케쥴러 도입

### DIFF
--- a/src/main/kotlin/org/appjam/smashing/SmashingApplication.kt
+++ b/src/main/kotlin/org/appjam/smashing/SmashingApplication.kt
@@ -3,7 +3,9 @@ package org.appjam.smashing
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
+@EnableScheduling
 @SpringBootApplication
 @ConfigurationPropertiesScan
 class SmashingApplication

--- a/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/game/service/GameService.kt
@@ -43,7 +43,6 @@ class GameService(
     private val gameRepository: GameRepository,
     private val userRepository: UserRepository,
     private val submissionRepository: GameResultSubmissionRepository,
-    private val gameReviewRepository: GameReviewRepository,
     private val notificationService: NotificationService,
     private val outboxEventPublisher: OutboxEventPublisher,
     private val gameReviewService: GameReviewService,

--- a/src/main/kotlin/org/appjam/smashing/domain/outbox/dto/SsePayload.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/outbox/dto/SsePayload.kt
@@ -1,8 +1,6 @@
 package org.appjam.smashing.domain.outbox.dto
 
-import org.appjam.smashing.domain.game.enums.GameSubmissionRejectReason
 import org.appjam.smashing.domain.game.enums.GameStatus
-import org.appjam.smashing.domain.notification.enums.NotificationType
 import org.appjam.smashing.domain.outbox.enums.MatchingUpdateStatus
 import org.appjam.smashing.domain.outbox.enums.SseEventType
 import org.appjam.smashing.domain.tier.enums.TierCode

--- a/src/main/kotlin/org/appjam/smashing/domain/outbox/enums/SseEventType.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/outbox/enums/SseEventType.kt
@@ -13,19 +13,6 @@ enum class SseEventType(
     // 매칭 엔티티 상태 업데이트 실시간 반영 (삭제(취소))
     MATCHING_UPDATED("matching.updated"),
 
-
-    // 매칭 수락 알림 생성
-    MATCHING_ACCEPT_NOTIFICATION_CREATED("matching.accept.notification.created"),
-
     // 게임 관련 변경 사항
     GAME_UPDATED("game.updated"),
-
-    // 게임 결과 제출 알림 생성
-    GAME_RESULT_SUBMITTED_NOTIFICATION_CREATED("game.result.submitted.notification.created"),
-
-    // 게임 결과 거절 알림 생성
-    GAME_RESULT_REJECTED_NOTIFICATION_CREATED("game.result.rejected.notification.created"),
-
-    // 리뷰 제출 알림 생성
-    REVIEW_RECEIVED_NOTIFICATION_CREATED("review.received.notification.created"),
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/outbox/repository/OutboxEventRepository.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/outbox/repository/OutboxEventRepository.kt
@@ -2,21 +2,21 @@ package org.appjam.smashing.domain.outbox.repository
 
 import org.appjam.smashing.domain.outbox.entity.OutboxEvent
 import org.appjam.smashing.domain.outbox.enums.OutboxEventStatus
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
-import org.springframework.data.domain.Pageable
 import java.time.LocalDateTime
 
 interface OutboxEventRepository : JpaRepository<OutboxEvent, String> {
 
     @Query("""
-    select e.id
-      from OutboxEvent e
-     where e.userId = :userId
-       and e.status = :status
-     order by e.id asc
-     """)
+        select e.id
+          from OutboxEvent e
+         where e.userId = :userId
+           and e.status = :status
+         order by e.id asc
+    """)
     fun findIdsByUserIdAndStatus(
         userId: String,
         status: OutboxEventStatus,
@@ -67,4 +67,18 @@ interface OutboxEventRepository : JpaRepository<OutboxEvent, String> {
         processing: OutboxEventStatus = OutboxEventStatus.PROCESSING,
         now: LocalDateTime,
     ): Int
+
+    @Query("""
+        select e
+          from OutboxEvent e
+         where e.status = :status
+           and e.lastAttemptAt is not null
+           and e.lastAttemptAt < :threshold
+         order by e.lastAttemptAt asc, e.id asc
+    """)
+    fun findStaleProcessingEvents(
+        status: OutboxEventStatus = OutboxEventStatus.PROCESSING,
+        threshold: LocalDateTime,
+        pageable: Pageable,
+    ): List<OutboxEvent>
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/outbox/service/OutboxEventService.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/outbox/service/OutboxEventService.kt
@@ -6,6 +6,8 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 import java.util.concurrent.Executor
 import java.util.concurrent.RejectedExecutionException
 
@@ -22,15 +24,22 @@ class OutboxEventService(
         try {
             outboxEventExecutor.execute {
                 runCatching {
-                    val ids = outboxEventRepository.findIdsByUserIdAndStatus(userId, OutboxEventStatus.PENDING, PageRequest.of(0, 200),)
+                    val ids = outboxEventRepository.findIdsByUserIdAndStatus(
+                        userId = userId,
+                        status = OutboxEventStatus.PENDING,
+                        pageable = PageRequest.of(0, PENDING_SEND_BATCH_SIZE),
+                    )
+
                     if (ids.isEmpty()) return@runCatching
+
                     ids.forEach { id ->
                         runCatching { outboxEventSender.send(id) }
                             .onFailure { ex ->
                                 log.warn("Outbox send failed in enqueuePendingSendsAsync. outboxEventId={}", id, ex)
                             }
                     }
-                }.onFailure { ex -> log.warn("enqueuePendingSendsAsync failed. userId={}", userId, ex)
+                }.onFailure { ex ->
+                    log.warn("enqueuePendingSendsAsync failed. userId={}", userId, ex)
                 }
             }
         } catch (ex: RejectedExecutionException) {
@@ -54,7 +63,63 @@ class OutboxEventService(
         }
     }
 
+    @Transactional
+    fun recoverStaleProcessingEvents() {
+        val now = LocalDateTime.now()
+        val threshold = now.minusSeconds(STALE_PROCESSING_SECONDS)
+
+        val staleEvents = outboxEventRepository.findStaleProcessingEvents(
+            threshold = threshold,
+            pageable = PageRequest.of(0, STALE_PROCESSING_BATCH_SIZE),
+        )
+
+        if (staleEvents.isEmpty()) return
+
+        staleEvents.forEach { event ->
+            val eventId = event.id
+            if (eventId == null) {
+                log.warn("Stale processing event id is null. userId={}, retryCount={}", event.userId, event.retryCount)
+                return@forEach
+            }
+
+            runCatching {
+                if (event.retryCount >= MAX_RETRY) {
+                    val updated = outboxEventRepository.markFailedIfProcessing(
+                        id = eventId,
+                        now = now,
+                    )
+
+                    if (updated == 1) {
+                        log.warn(
+                            "Recovered stale PROCESSING event to FAILED. outboxEventId={}, userId={}, retryCount={}",
+                            eventId, event.userId, event.retryCount
+                        )
+                    }
+                } else {
+                    val updated = outboxEventRepository.markPendingIfProcessing(
+                        id = eventId,
+                        now = now,
+                    )
+
+                    if (updated == 1) {
+                        log.warn(
+                            "Recovered stale PROCESSING event to PENDING. outboxEventId={}, userId={}, retryCount={}",
+                            eventId, event.userId, event.retryCount
+                        )
+                    }
+                }
+            }.onFailure { ex ->
+                log.error("Failed to recover stale PROCESSING event. outboxEventId={}", eventId, ex)
+            }
+        }
+    }
+
     companion object {
         private val log = LoggerFactory.getLogger(OutboxEventService::class.java)
+
+        private const val MAX_RETRY = 3
+        private const val PENDING_SEND_BATCH_SIZE = 200
+        private const val STALE_PROCESSING_SECONDS = 60L
+        private const val STALE_PROCESSING_BATCH_SIZE = 100
     }
 }

--- a/src/main/kotlin/org/appjam/smashing/domain/scheduler/OutboxEventRecoveryScheduler.kt
+++ b/src/main/kotlin/org/appjam/smashing/domain/scheduler/OutboxEventRecoveryScheduler.kt
@@ -1,0 +1,26 @@
+package org.appjam.smashing.domain.scheduler
+
+import org.appjam.smashing.domain.outbox.service.OutboxEventService
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class OutboxEventRecoveryScheduler(
+    private val outboxEventService: OutboxEventService,
+) {
+
+    @Scheduled(fixedDelay = RECOVERY_SCHEDULE_DELAY_MILLIS)
+    fun recoverStaleProcessingEvents() {
+        runCatching {
+            outboxEventService.recoverStaleProcessingEvents()
+        }.onFailure { ex ->
+            log.error("Outbox stale processing recovery scheduler failed.", ex)
+        }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(OutboxEventRecoveryScheduler::class.java)
+        private const val RECOVERY_SCHEDULE_DELAY_MILLIS = 30_000L
+    }
+}


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련 이슈 번호를 작성해주세요 -->
- closes #221 

## #️⃣ 요약 설명
- SSE 전송 과정에서 `PROCESSING` 상태에 고착된 outbox 이벤트를 복구할 수 있도록 스케줄러 기반 복구 로직을 추가합니다.
- 기존에는 비정상 종료 등으로 이벤트가 `PROCESSING` 상태에 머무르면 재전송 대상에서 제외되어 영구 누락될 가능성이 있었는데, 이를 방지하고자 합니다.

## 📝 작업 내용
- [x] `PROCESSING` 상태의 stale outbox 이벤트를 조회하는 repository 메서드 추가
- [x] `OutboxEventService`에 stale `PROCESSING` 이벤트 복구 로직 추가
- [x] 재시도 횟수에 따라 `PENDING` 또는 `FAILED`로 상태를 전환하도록 처리
- [x] 주기적으로 복구 로직을 실행하는 `OutboxEventRecoveryScheduler` 추가
- [x] 스케줄러 동작을 위해 `@EnableScheduling` 설정 추가
- [x] 복구 기준 시간, 배치 크기, 스케줄 주기 등의 값을 상수로 분리하여 관리하도록 수정

## 👍 동작 확인
<!-- 구현을 마치고 실제 테스트한 결과를 첨부해주세요 -->
- 내용

## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 내용